### PR TITLE
Bugfix for Telemetry

### DIFF
--- a/src/telemetry/basic_comp_counters.rs
+++ b/src/telemetry/basic_comp_counters.rs
@@ -92,6 +92,9 @@ pub async fn compress_tele_completion_to_file(
         }
         storage_locked.snippet_data_accumulators.clear();
     }
+    if records.as_array().unwrap().is_empty() {
+        return;
+    }
 
     let (dir, _) = utils::telemetry_storage_dirs(&cache_dir).await;
 

--- a/src/telemetry/basic_network.rs
+++ b/src/telemetry/basic_network.rs
@@ -56,9 +56,6 @@ pub async fn compress_basic_telemetry_to_file(
     let (dir, _) = telemetry_storage_dirs(&cache_dir).await;
 
     let records = compress_telemetry_network(storage.clone());
-    if records.as_array().unwrap().is_empty() {
-        return;
-    }
     let fn_net = dir.join(format!("{}-net.json", now.format("%Y%m%d-%H%M%S")));
     let mut big_json_net = json!({
         "records": records,
@@ -71,6 +68,9 @@ pub async fn compress_basic_telemetry_to_file(
         storage_locked.tele_net.clear();
         big_json_net.as_object_mut().unwrap().insert("ts_start".to_string(), json!(storage_locked.last_flushed_ts));
         storage_locked.last_flushed_ts = now.timestamp();
+    }
+    if records.as_array().unwrap().is_empty() {
+        return;
     }
     // even if there's an error with i/o, storage is now clear, preventing infinite memory growth
     info!("basic telemetry save \"{}\"", fn_net.to_str().unwrap());

--- a/src/telemetry/basic_network.rs
+++ b/src/telemetry/basic_network.rs
@@ -56,6 +56,9 @@ pub async fn compress_basic_telemetry_to_file(
     let (dir, _) = telemetry_storage_dirs(&cache_dir).await;
 
     let records = compress_telemetry_network(storage.clone());
+    if records.as_array().unwrap().is_empty() {
+        return;
+    }
     let fn_net = dir.join(format!("{}-net.json", now.format("%Y%m%d-%H%M%S")));
     let mut big_json_net = json!({
         "records": records,

--- a/src/telemetry/basic_robot_human.rs
+++ b/src/telemetry/basic_robot_human.rs
@@ -51,6 +51,7 @@ pub fn increase_counters_from_finished_snippet(
             rec.robot_characters_acc_baseline = 0;
             rec.baseline_text = text.clone();
         }
+        // info!("increasing for {}, human+{}, robot+{}", snip.snippet_telemetry_id, human_characters(rec, text), rec.robot_characters_acc_baseline);
     } else {
         let init_file_text_mb = snip.inputs.sources.get(&snip.inputs.cursor.file);
         if init_file_text_mb.is_none() {
@@ -112,6 +113,9 @@ pub async fn tele_robot_human_compress_to_file(
             records.as_array_mut().unwrap().push(json_dict);
         }
         storage_locked.tele_robot_human.clear();
+    }
+    if records.as_array().unwrap().is_empty() {
+        return;
     }
     let (dir, _) = utils::telemetry_storage_dirs(&cache_dir).await;
 

--- a/src/telemetry/basic_transmit.rs
+++ b/src/telemetry/basic_transmit.rs
@@ -15,7 +15,7 @@ use crate::telemetry::basic_comp_counters;
 use crate::telemetry::utils::{sorted_json_files, read_file, cleanup_old_files, telemetry_storage_dirs};
 
 
-const TELEMETRY_TRANSMIT_EACH_N_SECONDS: u64 = 3600;
+const TELEMETRY_TRANSMIT_EACH_N_SECONDS: u64 = 3600*3;
 const TELEMETRY_FILES_KEEP: i32 = 30;
 
 
@@ -67,7 +67,7 @@ pub async fn send_telemetry_files_to_mothership(
         let path_str = path.to_str().unwrap();
         if path_str.ends_with("-net.json") || path_str.ends_with("-rh.json") || path_str.ends_with("-comp.json") {
             info!("sending telemetry file\n{}\nto url\n{}", path.to_str().unwrap(), telemetry_basic_dest);
-            let resp = send_telemetry_data(contents, &telemetry_basic_dest, 
+            let resp = send_telemetry_data(contents, &telemetry_basic_dest,
                                            &api_key, gcx.clone()).await;
             if resp.is_err() {
                 error!("telemetry send failed: {}", resp.err().unwrap());

--- a/src/telemetry/basic_transmit.rs
+++ b/src/telemetry/basic_transmit.rs
@@ -15,6 +15,7 @@ use crate::telemetry::basic_comp_counters;
 use crate::telemetry::utils::{sorted_json_files, read_file, cleanup_old_files, telemetry_storage_dirs};
 
 
+const TELEMETRY_TRANSMIT_AFTER_START_SECONDS: u64 = 60;
 const TELEMETRY_TRANSMIT_EACH_N_SECONDS: u64 = 3600*3;
 const TELEMETRY_FILES_KEEP: i32 = 30;
 
@@ -138,8 +139,8 @@ pub async fn telemetry_background_task(
     global_context: Arc<ARwLock<global_context::GlobalContext>>,
 ) -> () {
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(30)).await; // workaround waiting for caps to load
+        tokio::time::sleep(tokio::time::Duration::from_secs(TELEMETRY_TRANSMIT_AFTER_START_SECONDS)).await;
         telemetry_full_cycle(global_context.clone(), false).await;
-        tokio::time::sleep(tokio::time::Duration::from_secs(TELEMETRY_TRANSMIT_EACH_N_SECONDS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(TELEMETRY_TRANSMIT_EACH_N_SECONDS - TELEMETRY_TRANSMIT_AFTER_START_SECONDS)).await;
     }
 }

--- a/src/telemetry/basic_transmit.rs
+++ b/src/telemetry/basic_transmit.rs
@@ -15,7 +15,7 @@ use crate::telemetry::basic_comp_counters;
 use crate::telemetry::utils::{sorted_json_files, read_file, cleanup_old_files, telemetry_storage_dirs};
 
 
-const TELEMETRY_TRANSMIT_EACH_N_SECONDS: u64 = 3600*3;
+const TELEMETRY_TRANSMIT_EACH_N_SECONDS: u64 = 3600;
 const TELEMETRY_FILES_KEEP: i32 = 30;
 
 

--- a/src/telemetry/basic_transmit.rs
+++ b/src/telemetry/basic_transmit.rs
@@ -138,7 +138,8 @@ pub async fn telemetry_background_task(
     global_context: Arc<ARwLock<global_context::GlobalContext>>,
 ) -> () {
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(TELEMETRY_TRANSMIT_EACH_N_SECONDS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(30)).await; // workaround waiting for caps to load
         telemetry_full_cycle(global_context.clone(), false).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(TELEMETRY_TRANSMIT_EACH_N_SECONDS)).await;
     }
 }


### PR DESCRIPTION
found 2 potential bugs that could lead to loss of telemetry:

1. 3600 * 3s before sending telemetry
2. compressing tele with empty records that caused wiping tele with non-empty records, so we had nothing to send.

Bug 1, 2 are fixed in this commit.