### PR TITLE
default system prompt update

### DIFF
--- a/src/http/routers/v1/toolbox.rs
+++ b/src/http/routers/v1/toolbox.rs
@@ -11,15 +11,14 @@ use tracing::error;
 use crate::call_validation::ChatMessage;
 use crate::global_context::GlobalContext;
 use crate::custom_error::ScratchError;
+use crate::toolbox::toolbox_config::get_tconfig;
 
 
 pub async fn handle_v1_customization(
     Extension(global_context): Extension<Arc<ARwLock<GlobalContext>>>,
     _body_bytes: hyper::body::Bytes,
 ) -> Result<Response<Body>, ScratchError> {
-    let gcx: Arc<ARwLock<GlobalContext>> = global_context.clone();
-    let cache_dir = gcx.read().await.cache_dir.clone();
-	let tconfig = match crate::toolbox::toolbox_config::load_customization_high_level(cache_dir) {
+	let tconfig = match get_tconfig(global_context.clone()).await {
 		Ok(config) => config,
 		Err(err) => {
 			error!("load_customization_high_level: {}", err);

--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -103,9 +103,7 @@ pub const KNOWN_MODELS: &str = r####"
         "gpt-3.5-turbo": {
             "n_ctx": 4096,
             "supports_scratchpads": {
-                "PASSTHROUGH": {
-                    "default_system_message": "You are a coding assistant that outputs short answers, gives links to documentation."
-                }
+                "PASSTHROUGH": {}
             },
             "similar_models": [
                 "gpt-4",
@@ -115,9 +113,7 @@ pub const KNOWN_MODELS: &str = r####"
         "claude-instant-1.2": {
             "n_ctx": 4096,
             "supports_scratchpads": {
-                "PASSTHROUGH": {
-                    "default_system_message": "You are a coding assistant that outputs short answers, gives links to documentation."
-                }
+                "PASSTHROUGH": {}
             },
             "similar_models": [
                 "claude-2.1",

--- a/src/scratchpad_abstract.rs
+++ b/src/scratchpad_abstract.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 #[async_trait]
 pub trait ScratchpadAbstract: Send {
-    fn apply_model_adaptation_patch(
+    async fn apply_model_adaptation_patch(
         &mut self,
         patch: &serde_json::Value,
     ) -> Result<(), String>;

--- a/src/scratchpads/chat_llama2.rs
+++ b/src/scratchpads/chat_llama2.rs
@@ -11,6 +11,7 @@ use crate::call_validation::{ChatMessage, ChatPost, ContextFile, SamplingParamet
 use crate::global_context::GlobalContext;
 use crate::scratchpad_abstract::HasTokenizerAndEot;
 use crate::scratchpad_abstract::ScratchpadAbstract;
+use crate::scratchpads::chat_generic::default_system_message_from_patch;
 use crate::scratchpads::chat_utils_deltadelta::DeltaDeltaChatStreamer;
 use crate::scratchpads::chat_utils_limit_history::limit_messages_history;
 use crate::scratchpads::chat_utils_rag::{run_at_commands, HasVecdbResults};
@@ -52,13 +53,13 @@ impl ChatLlama2 {
 
 #[async_trait]
 impl ScratchpadAbstract for ChatLlama2 {
-    fn apply_model_adaptation_patch(
+    async fn apply_model_adaptation_patch(
         &mut self,
-        patch: &serde_json::Value,
+        patch: &Value,
     ) -> Result<(), String> {
         self.keyword_s = patch.get("s").and_then(|x| x.as_str()).unwrap_or("<s>").to_string();
         self.keyword_slash_s = patch.get("slash_s").and_then(|x| x.as_str()).unwrap_or("</s>").to_string();
-        self.default_system_message = patch.get("default_system_message").and_then(|x| x.as_str()).unwrap_or("").to_string();
+        self.default_system_message = default_system_message_from_patch(&patch, self.global_context.clone()).await;
         self.t.eot = self.keyword_s.clone();
         info!("llama2 chat model adaptation patch applied {:?}", self.keyword_s);
         self.t.assert_one_token(&self.t.eot.as_str())?;

--- a/src/scratchpads/chat_passthrough.rs
+++ b/src/scratchpads/chat_passthrough.rs
@@ -11,6 +11,7 @@ use crate::call_validation::{ChatMessage, ChatPost, ContextFile, SamplingParamet
 use crate::global_context::GlobalContext;
 use crate::scratchpad_abstract::HasTokenizerAndEot;
 use crate::scratchpad_abstract::ScratchpadAbstract;
+use crate::scratchpads::chat_generic::default_system_message_from_patch;
 use crate::scratchpads::chat_utils_limit_history::limit_messages_history;
 use crate::scratchpads::chat_utils_rag::{run_at_commands, HasVecdbResults};
 
@@ -44,11 +45,11 @@ impl ChatPassthrough {
 
 #[async_trait]
 impl ScratchpadAbstract for ChatPassthrough {
-    fn apply_model_adaptation_patch(
+    async fn apply_model_adaptation_patch(
         &mut self,
-        patch: &serde_json::Value,
+        patch: &Value,
     ) -> Result<(), String> {
-        self.default_system_message = patch.get("default_system_message").and_then(|x| x.as_str()).unwrap_or("").to_string();
+        self.default_system_message = default_system_message_from_patch(&patch, self.global_context.clone()).await;
         Ok(())
     }
 
@@ -60,13 +61,10 @@ impl ScratchpadAbstract for ChatPassthrough {
         info!("chat passthrough {} messages at start", &self.post.messages.len());
         let top_n: usize = 10;
         let last_user_msg_starts = run_at_commands(self.global_context.clone(), self.t.tokenizer.clone(), sampling_parameters_to_patch.max_new_tokens, context_size, &mut self.post, top_n, &mut self.has_vecdb_results).await;
-        let limited_msgs: Vec<ChatMessage> = match limit_messages_history(&self.t, &self.post.messages, last_user_msg_starts, sampling_parameters_to_patch.max_new_tokens, context_size, &self.default_system_message) {
-            Ok(res) => res,
-            Err(e) => {
-                error!("error limiting messages: {}", e);
-                vec![]
-            }
-        };
+        let limited_msgs: Vec<ChatMessage> = limit_messages_history(&self.t, &self.post.messages, last_user_msg_starts, sampling_parameters_to_patch.max_new_tokens, context_size, &self.default_system_message).unwrap_or_else(|e| {
+            error!("error limiting messages: {}", e);
+            vec![]
+        });
         info!("chat passthrough {} messages -> {} messages after applying at-commands and limits, possibly adding the default system message", &self.post.messages.len(), &limited_msgs.len());
         let mut filtered_msgs: Vec<ChatMessage> = Vec::<ChatMessage>::new();
         for msg in &limited_msgs {

--- a/src/scratchpads/completion_single_file_fim.rs
+++ b/src/scratchpads/completion_single_file_fim.rs
@@ -118,7 +118,7 @@ fn add_context_to_prompt(context_format: &String, prompt: &String, fim_prefix: &
 
 #[async_trait]
 impl ScratchpadAbstract for SingleFileFIM {
-    fn apply_model_adaptation_patch(
+    async fn apply_model_adaptation_patch(
         &mut self,
         patch: &Value,
     ) -> Result<(), String> {

--- a/src/scratchpads/mod.rs
+++ b/src/scratchpads/mod.rs
@@ -45,7 +45,7 @@ pub async fn create_code_completion_scratchpad(
     } else {
         return Err(format!("This rust binary doesn't have code completion scratchpad \"{}\" compiled in", scratchpad_name));
     }
-    result.apply_model_adaptation_patch(scratchpad_patch)?;
+    result.apply_model_adaptation_patch(scratchpad_patch).await?;
     verify_has_send(&result);
     Ok(result)
 }
@@ -71,7 +71,7 @@ pub async fn create_chat_scratchpad(
     } else {
         return Err(format!("This rust binary doesn't have chat scratchpad \"{}\" compiled in", scratchpad_name));
     }
-    result.apply_model_adaptation_patch(scratchpad_patch)?;
+    result.apply_model_adaptation_patch(scratchpad_patch).await?;
     verify_has_send(&result);
     Ok(result)
 }

--- a/src/toolbox/toolbox_compiled_in.rs
+++ b/src/toolbox/toolbox_compiled_in.rs
@@ -14,6 +14,7 @@ pub const COMPILED_IN_CUSTOMIZATION_YAML : &str = r#"# Customization will merge 
 DEFAULT_PROMPT: |
   Use backquotes for code blocks.
   Pay close attention to indent when editing code blocks: indent must be exactly the same as in the original code block.
+  Write math expressions in a markdown style: $x^2$ when inside line; $$x^2$$ when in a new line;
 
 system_prompts:
   default:


### PR DESCRIPTION
Changelist:
* chat correctly wraps math expressions with $$ (markdown style)
* passthrough models don't have their own default prompt
* if not default prompt for chat model -> use default system prompt for yaml