### PR TITLE
att ast tools fix 

### DIFF
--- a/src/ast/ast_module.rs
+++ b/src/ast/ast_module.rs
@@ -162,7 +162,8 @@ impl AstModule {
                     .iter()
                     .take(top_n)
                     .filter_map(|s| {
-                        let info_struct = s.borrow().symbol_info_struct();
+                        let mut info_struct = s.borrow().symbol_info_struct();
+                        info_struct.symbol_path = ast_ref.get_symbol_full_path(s);
                         let name = info_struct.name.clone();
                         let content = info_struct.get_content_from_file_blocked().ok()?;
                         Some(SymbolsSearchResultStruct {
@@ -209,7 +210,8 @@ impl AstModule {
                     .iter()
                     .take(top_n)
                     .filter_map(|s| {
-                        let info_struct = s.borrow().symbol_info_struct();
+                        let mut info_struct = s.borrow().symbol_info_struct();
+                        info_struct.symbol_path = ast_ref.get_symbol_full_path(s);
                         let name = info_struct.name.clone();
                         let content = info_struct.get_content_from_file_blocked().ok()?;
                         Some(SymbolsSearchResultStruct {

--- a/src/at_tools/att_ast_definition.rs
+++ b/src/at_tools/att_ast_definition.rs
@@ -1,14 +1,16 @@
+use std::cmp::max;
 use std::collections::HashMap;
-use async_trait::async_trait;
-use serde_json::Value;
-use itertools::Itertools;
 
+use async_trait::async_trait;
+use itertools::Itertools;
+use serde_json::Value;
+
+use crate::ast::ast_index::RequestSymbolType;
+use crate::ast::structs::AstQuerySearchResult;
 use crate::at_commands::at_ast_definition::results2message;
 use crate::at_commands::at_commands::AtCommandsContext;
-use crate::call_validation::{ChatMessage, ContextEnum};
 use crate::at_tools::tools::AtTool;
-use crate::ast::ast_index::RequestSymbolType;
-
+use crate::call_validation::{ChatMessage, ContextEnum};
 
 pub struct AttAstDefinition;
 
@@ -17,63 +19,83 @@ impl AtTool for AttAstDefinition {
     async fn execute(&self, ccx: &mut AtCommandsContext, tool_call_id: &String, args: &HashMap<String, Value>) -> Result<Vec<ContextEnum>, String> {
         let mut symbol = match args.get("symbol") {
             Some(Value::String(s)) => s.clone(),
-            Some(v) => { return Err(format!("argument `symbol` is not a string: {:?}", v)) },
+            Some(v) => { return Err(format!("argument `symbol` is not a string: {:?}", v)) }
             None => { return Err("argument `symbol` is missing".to_string()) }
         };
 
         if let Some(dot_index) = symbol.find('.') {
-            symbol = symbol[dot_index+1..].to_string();
+            symbol = symbol[dot_index + 1..].to_string();
         }
 
         let ast_mb = ccx.global_context.read().await.ast_module.clone();
         let ast = ast_mb.ok_or_else(|| "AST support is turned off".to_string())?;
 
-        let search_results: crate::ast::structs::AstQuerySearchResult = ast.read().await.search_by_fullpath(
+        let mut found_by_fuzzy_search: bool = false;
+        let mut res: AstQuerySearchResult = ast.read().await.search_by_fullpath(
             symbol.clone(),
             RequestSymbolType::Declaration,
             false,
             ccx.top_n,
         ).await?;
-        if search_results.search_results.len() == 0 {
-            let search_results_fuzzy: crate::ast::structs::AstQuerySearchResult = ast.read().await.search_by_fullpath(
+        res = if res.search_results.is_empty() {
+            found_by_fuzzy_search = true;
+            ast.read().await.search_by_fullpath(
                 symbol.clone(),
                 RequestSymbolType::Declaration,
                 true,
-                6,
-            ).await?;
-            if search_results_fuzzy.search_results.len() == 0 {
-                return Err(format!("There is no `{}` in the syntax tree, and no similar names found :/", symbol).to_string());
-            } else {
-                let mut s = String::new();
-                s.push_str(format!("There is no `{}` in the syntax tree, call again with one of these close names:\n", symbol).as_str());
-                let all_names_unique = search_results_fuzzy.search_results.iter()
-                    .map(|r| r.symbol_declaration.name.clone())
-                    .sorted()
-                    .unique()
-                    .collect::<Vec<String>>();
-                for x in all_names_unique.iter() {
-                    s.push_str(&format!("{}\n", x));
-                }
-                return Err(s);
-            }
+                max(ccx.top_n, 6),
+            ).await?
+        } else {
+            res
+        };
+        if res.search_results.is_empty() {
+            return Err(format!("There is no `{}` in the syntax tree, and no similar names found :/", symbol).to_string());
         }
-        let mut results = results2message(&search_results).await
-            .into_iter().map(|x| ContextEnum::ContextFile(x)).collect::<Vec<ContextEnum>>();
 
-        let mut s = String::new();
-        s.push_str(format!("Definition of `{}` found at:\n", symbol).as_str());
-        for r in search_results.search_results.iter() {
-            let file_path_str = r.symbol_declaration.file_path.to_str().unwrap().to_string();
-            let decl_range = &r.symbol_declaration.full_range;
-            s.push_str(&format!("{}:{}-{}\n", file_path_str, decl_range.start_point.row + 1, decl_range.end_point.row + 1));
-        }
-        results.push(ContextEnum::ChatMessage(ChatMessage {
+        let (mut messages, tool_message) = if found_by_fuzzy_search {
+            let messages = results2message(&res)
+                .await
+                .into_iter()
+                .map(|x| ContextEnum::ContextFile(x))
+                .take(1)
+                .collect::<Vec<ContextEnum>>();
+            let found_path = res.search_results[0].symbol_declaration.symbol_path.clone();
+            let other_names = res.search_results
+                .iter()
+                .skip(1)
+                .map(|r| r.symbol_declaration.symbol_path.clone())
+                .sorted()
+                .unique()
+                .collect::<Vec<String>>();
+            let mut tool_message = format!(
+                "Definition of `{symbol}` haven't found by exact name, but found the close result`{found_path}`. \
+                You can call again with one of these other names:\n"
+            ).to_string();
+            for x in other_names.into_iter() {
+                tool_message.push_str(&format!("{}\n", x));
+            }
+            (messages, tool_message)
+        } else {
+            let messages = results2message(&res)
+                .await
+                .into_iter().map(|x| ContextEnum::ContextFile(x))
+                .collect::<Vec<ContextEnum>>();
+            let mut tool_message = format!("Definition of `{}` found at:\n", symbol).to_string();
+            for r in res.search_results.iter() {
+                let file_path_str = r.symbol_declaration.symbol_path.to_string();
+                let decl_range = &r.symbol_declaration.full_range;
+                tool_message.push_str(&format!("{}:{}-{}\n", file_path_str, decl_range.start_point.row + 1, decl_range.end_point.row + 1));
+            }
+            (messages, tool_message)
+        };
+
+        messages.push(ContextEnum::ChatMessage(ChatMessage {
             role: "tool".to_string(),
-            content: s.clone(),
+            content: tool_message.clone(),
             tool_calls: None,
             tool_call_id: tool_call_id.clone(),
         }));
-        Ok(results)
+        Ok(messages)
     }
 
     fn depends_on(&self) -> Vec<String> {


### PR DESCRIPTION
- Add method `get_symbol_full_path` to `AstIndex` and refactor calls
- Introduce `get_symbol_full_path` method in `AstIndex` to replace the original `get_symbol_full_path` function.
- Update existing calls to use the new `AstIndex::get_symbol_full_path` method.
- Refactor `AttAstDefinition` and `AttAstReference` to improve handling of symbol search results and messages.