### PR TITLE
wip(csp): add `Content-Security-Provider` header for chat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 serde_yaml = "0.9.31"
 tower = { version = "0.4", features = ["full"] }
 tower-lsp = "0.20"
-tower-http = { version = "0.4.0" }
+tower-http = { version = "0.4.0", features = ["cors"] }
 tower-layer = "0.3.2"
 tracing = "0.1"
 tracing-appender = "0.2.3"

--- a/src/http/routers/v1.rs
+++ b/src/http/routers/v1.rs
@@ -7,6 +7,8 @@ use axum::routing::post;
 use futures::Future;
 use hyper::Body;
 use hyper::Response;
+use tower_http::cors::CorsLayer;
+
 
 use crate::{telemetry_get, telemetry_post};
 use crate::custom_error::ScratchError;
@@ -105,4 +107,5 @@ pub fn make_v1_router() -> Router {
         .route("/mem-list", telemetry_get!(handle_mem_list))
         .route("/ongoing-update", telemetry_post!(handle_ongoing_update_or_create))
         .route("/ongoing-dump", telemetry_get!(handle_ongoing_dump))
+        .layer(CorsLayer::very_permissive())
 }


### PR DESCRIPTION
Currently this opens all endpoint to chat