### PR TITLE
better fuzzy search

### DIFF
--- a/src/files_in_workspace.rs
+++ b/src/files_in_workspace.rs
@@ -103,7 +103,7 @@ pub struct DocumentsState {
     pub memory_document_map: HashMap<PathBuf, Arc<ARwLock<Document>>>,   // if a file is open in IDE, and it's outside workspace dirs, it will be in this map and not in workspace_files
     pub cache_dirty: Arc<AMutex<bool>>,
     pub cache_correction: Arc<HashMap<String, HashSet<String>>>,  // map dir3/file.ext -> to /dir1/dir2/dir3/file.ext
-    pub cache_fuzzy: Arc<Vec<String>>,                            // slow linear search
+    pub cache_fuzzy: Arc<HashMap<String, String>>,                   // slow linear search
     pub fs_watcher: Arc<ARwLock<RecommendedWatcher>>,
     pub total_reset: bool,
     pub total_reset_ts: std::time::SystemTime,
@@ -140,7 +140,7 @@ impl DocumentsState {
             memory_document_map: HashMap::new(),
             cache_dirty: Arc::new(AMutex::<bool>::new(false)),
             cache_correction: Arc::new(HashMap::<String, HashSet<String>>::new()),
-            cache_fuzzy: Arc::new(Vec::<String>::new()),
+            cache_fuzzy: Arc::new(HashMap::<String, String>::new()),
             fs_watcher: Arc::new(ARwLock::new(watcher)),
             total_reset: false,
             total_reset_ts: std::time::SystemTime::now(),

--- a/src/files_in_workspace.rs
+++ b/src/files_in_workspace.rs
@@ -102,8 +102,10 @@ pub struct DocumentsState {
     // query on windows: C:/Users/user/Documents/file.ext
     pub memory_document_map: HashMap<PathBuf, Arc<ARwLock<Document>>>,   // if a file is open in IDE, and it's outside workspace dirs, it will be in this map and not in workspace_files
     pub cache_dirty: Arc<AMutex<bool>>,
-    pub cache_correction: Arc<HashMap<String, HashSet<String>>>,  // map dir3/file.ext -> to /dir1/dir2/dir3/file.ext
-    pub cache_fuzzy: Arc<HashMap<String, String>>,                   // slow linear search
+    pub cache_correction_files: Arc<HashMap<String, HashSet<String>>>,  // map dir3/file.ext -> to /dir1/dir2/dir3/file.ext
+    pub cache_fuzzy_files: Arc<HashMap<String, String>>,                // slow linear search
+    pub cache_correction_dirs: Arc<HashMap<String, HashSet<String>>>,
+    pub cache_fuzzy_dirs: Arc<HashMap<String, String>>,
     pub fs_watcher: Arc<ARwLock<RecommendedWatcher>>,
     pub total_reset: bool,
     pub total_reset_ts: std::time::SystemTime,
@@ -139,8 +141,10 @@ impl DocumentsState {
             jsonl_files: Arc::new(StdMutex::new(Vec::new())),
             memory_document_map: HashMap::new(),
             cache_dirty: Arc::new(AMutex::<bool>::new(false)),
-            cache_correction: Arc::new(HashMap::<String, HashSet<String>>::new()),
-            cache_fuzzy: Arc::new(HashMap::<String, String>::new()),
+            cache_correction_files: Arc::new(HashMap::<String, HashSet<String>>::new()),
+            cache_fuzzy_files: Arc::new(HashMap::<String, String>::new()),
+            cache_correction_dirs: Arc::new(HashMap::<String, HashSet<String>>::new()),
+            cache_fuzzy_dirs: Arc::new(HashMap::<String, String>::new()),
             fs_watcher: Arc::new(ARwLock::new(watcher)),
             total_reset: false,
             total_reset_ts: std::time::SystemTime::now(),


### PR DESCRIPTION
Changes:
If candidate to search has a parent that is a part of dirs_correction_map, all search results will be pre-filtered with this value:
Example:
candidate to search:
`tests/emergency_frog_situation/f`
pre-filter with:
`tests/emergency_frog_situation `
output:
```
['tests/emergency_frog_situation/frog.py ', 'tests/emergency_frog_situation/jump_to_conclusions.py ', 'tests/emergency_frog_situation/set_as_avatar.py ', 'tests/emergency_frog_situation/work_day.py ', 'tests/emergency_frog_situation/holiday.py ']
````