### PR TITLE
Ast fuzzy search

### DIFF
--- a/src/ast/ast_db.rs
+++ b/src/ast/ast_db.rs
@@ -813,7 +813,7 @@ pub async fn definition_paths_fuzzy(ast_index: Arc<AMutex<AstDB>>, pattern: &str
         }
     }
 
-    let results = fuzzy_search(&pattern.to_string(), candidates, top_n, ':');
+    let results = fuzzy_search(&pattern.to_string(), candidates, top_n, &[':']);
 
     results.into_iter()
         .map(|result| {

--- a/src/ast/ast_db.rs
+++ b/src/ast/ast_db.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 
 use crate::ast::ast_structs::{AstDB, AstDefinition, AstCounters, AstErrorStats};
 use crate::ast::ast_parse_anything::{parse_anything_and_add_file_path, filesystem_path_to_double_colon_path};
-use crate::files_correction::fuzzy_search;
+use crate::fuzzy_search::fuzzy_search;
 
 // ## How the database works ##
 //
@@ -783,13 +783,11 @@ pub async fn definition_paths_fuzzy(ast_index: Arc<AMutex<AstDB>>, pattern: &str
     let mut found = HashSet::new();
     let mut patterns_to_try = Vec::new();
 
-    // Generate patterns by chopping off parts from the beginning
     let parts: Vec<&str> = pattern.split("::").collect();
     for i in 0..parts.len() {
         patterns_to_try.push(parts[i..].join("::"));
     }
 
-    // Generate patterns by splitting the filename by halves
     if let Some(filename_part) = parts.last() {
         let mut filename = filename_part.to_string();
         while !filename.is_empty() {

--- a/src/at_commands/at_ast_definition.rs
+++ b/src/at_commands/at_ast_definition.rs
@@ -78,7 +78,7 @@ impl AtParam for AtParamSymbolPathQuery {
         }
         let ast_index = ast_service_opt.unwrap().lock().await.ast_index.clone();
 
-        let names = crate::ast::ast_db::definition_paths_fuzzy(ast_index, value).await;
+        let names = crate::ast::ast_db::definition_paths_fuzzy(ast_index, value, top_n, 500).await;
 
         let filtered_paths = names
             .iter()

--- a/src/at_commands/at_ast_definition.rs
+++ b/src/at_commands/at_ast_definition.rs
@@ -78,15 +78,7 @@ impl AtParam for AtParamSymbolPathQuery {
         }
         let ast_index = ast_service_opt.unwrap().lock().await.ast_index.clone();
 
-        let names = crate::ast::ast_db::definition_paths_fuzzy(ast_index, value, top_n, 500).await;
-
-        let filtered_paths = names
-            .iter()
-            .take(top_n)
-            .cloned()
-            .collect::<Vec<String>>();
-
-        filtered_paths
+        crate::ast::ast_db::definition_paths_fuzzy(ast_index, value, top_n, 500).await
     }
 
     fn param_completion_valid(&self) -> bool {

--- a/src/at_commands/at_ast_definition.rs
+++ b/src/at_commands/at_ast_definition.rs
@@ -78,7 +78,7 @@ impl AtParam for AtParamSymbolPathQuery {
         }
         let ast_index = ast_service_opt.unwrap().lock().await.ast_index.clone();
 
-        crate::ast::ast_db::definition_paths_fuzzy(ast_index, value, top_n, 500).await
+        crate::ast::ast_db::definition_paths_fuzzy(ast_index, value, top_n, 1000).await
     }
 
     fn param_completion_valid(&self) -> bool {

--- a/src/files_correction.rs
+++ b/src/files_correction.rs
@@ -6,6 +6,7 @@ use tokio::sync::RwLock as ARwLock;
 use tracing::info;
 
 use crate::global_context::GlobalContext;
+use crate::fuzzy_search::fuzzy_search;
 
 pub async fn paths_from_anywhere(global_context: Arc<ARwLock<GlobalContext>>) -> Vec<PathBuf> {
     let file_paths_from_memory = global_context.read().await.documents_state.memory_document_map.keys().map(|x|x.clone()).collect::<Vec<_>>();
@@ -114,78 +115,6 @@ pub async fn files_cache_rebuild_as_needed(global_context: Arc<ARwLock<GlobalCon
     }
 
     return (cache_correction_arc, cache_shortened_arc);
-}
-
-pub fn fuzzy_search<I>(
-    correction_candidate: &String,
-    candidates: I,
-    top_n: usize,
-    separator_first_char: char,
-) -> Vec<String>
-where I: IntoIterator<Item = String> {
-    const FILENAME_WEIGHT: i32 = 3;
-    const DISTANCE_THRESHOLD: f64 = 0.45;
-    const EXCESS_WEIGHT: f64 = 3.0;
-
-    let mut correction_bigram_count: HashMap<(char, char), i32> = HashMap::new();
-
-    // Count bigrams of correction candidate
-    let mut correction_candidate_length = 0;
-    let mut weight = FILENAME_WEIGHT;
-    for window in correction_candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-        if window[0] == separator_first_char {
-            weight = 1;
-        }
-        correction_candidate_length += weight;
-        *correction_bigram_count
-            .entry((window[0], window[1]))
-            .or_insert(0) += weight;
-    }
-
-    let mut top_n_candidates = Vec::new();
-
-    for candidate in candidates {
-        let mut missing_count: i32 = 0;
-        let mut excess_count = 0;
-        let mut candidate_len = 0;
-        let mut bigram_count = correction_bigram_count.clone();
-
-        // Discount candidate's bigrams from correction candidate's ones
-        let mut weight = FILENAME_WEIGHT;
-        for window in candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-            if window[0] == separator_first_char {
-                weight = 1;
-            }
-            candidate_len += weight;
-            if let Some(entry) = bigram_count.get_mut(&(window[0], window[1])) {
-                *entry -= weight;
-            } else {
-                missing_count += weight;
-            }
-        }
-
-        for (&_, &count) in bigram_count.iter() {
-            if count > 0 {
-                excess_count += count;
-            } else {
-                missing_count += -count;
-            }
-        }
-
-        let distance = (missing_count as f64 + excess_count as f64 * EXCESS_WEIGHT) /
-            (correction_candidate_length as f64 + (candidate_len as f64) * EXCESS_WEIGHT);
-        if distance < DISTANCE_THRESHOLD {
-            top_n_candidates.push((candidate, distance));
-            top_n_candidates
-                .sort_by(|a, b| a.1.partial_cmp(&b.1)
-                .unwrap_or(std::cmp::Ordering::Equal));
-            if top_n_candidates.len() > top_n {
-                top_n_candidates.pop();
-            }
-        }
-    }
-
-    top_n_candidates.into_iter().map(|x| x.0).collect()
 }
 
 pub async fn correct_to_nearest_filename(
@@ -350,94 +279,6 @@ pub fn canonical_path(s: &String) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::files_in_workspace::retrieve_files_in_workspace_folders;
-
-    async fn get_candidates_from_workspace_files() -> Vec<String> {
-        let proj_folders = vec![PathBuf::from(".").canonicalize().unwrap()];
-        let proj_folder = &proj_folders[0];
-
-        let workspace_files = retrieve_files_in_workspace_folders(proj_folders.clone()).await;
-
-        workspace_files
-            .iter()
-            .filter_map(|path| {
-                let relative_path = path.strip_prefix(proj_folder)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .to_string();
-
-                    Some(relative_path)
-            })
-            .collect()
-    }
-
-    #[tokio::test]
-    async fn test_fuzzy_search_finds_frog_py() {
-        // Arrange
-        let correction_candidate = "frog.p".to_string();
-        let top_n = 1;
-
-        let candidates = get_candidates_from_workspace_files().await;
-
-        // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
-
-        // Assert
-        let expected_result = vec![
-            PathBuf::from("tests").join("emergency_frog_situation").join("frog.py").to_string_lossy().to_string(),
-        ];
-
-        assert_eq!(result, expected_result, "It should find the proper frog.py, found {:?} instead", result);
-    }
-
-    #[tokio::test]
-    async fn test_fuzzy_search_path_helps_finding_file() {
-        // Arrange
-        let correction_candidate = PathBuf::from("emergency_frog_situation").join("wo").to_string_lossy().to_string();
-        let top_n = 1;
-
-        let candidates = get_candidates_from_workspace_files().await;
-
-        // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
-
-        // Assert
-        let expected_result = vec![
-            PathBuf::from("tests").join("emergency_frog_situation").join("work_day.py").to_string_lossy().to_string(),
-        ];
-
-        assert_eq!(result, expected_result, "It should find the proper file (work_day.py), found {:?} instead", result);
-    }
-
-    #[tokio::test]
-    async fn test_fuzzy_search_filename_weights_more_than_path() {
-        // Arrange
-        let correction_candidate = "my_file.ext".to_string();
-        let top_n = 2;
-
-        let candidates = vec![
-            PathBuf::from("my_library").join("implementation").join("my_file.ext").to_string_lossy().to_string(),
-            PathBuf::from("my_library").join("my_file.ext").to_string_lossy().to_string(),
-            PathBuf::from("another_file.ext").to_string_lossy().to_string(),
-        ];
-
-        // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
-
-        // Assert
-        let expected_result = vec![
-            PathBuf::from("my_library").join("my_file.ext").to_string_lossy().to_string(),
-            PathBuf::from("my_library").join("implementation").join("my_file.ext").to_string_lossy().to_string(),
-        ];
-
-        let mut sorted_result = result.clone();
-        let mut sorted_expected = expected_result.clone();
-
-        sorted_result.sort();
-        sorted_expected.sort();
-
-        assert_eq!(sorted_result, sorted_expected, "The result should contain the expected paths in any order, found {:?} instead", result);
-    }
 
     #[test]
     fn test_make_cache() {
@@ -542,45 +383,5 @@ mod tests {
 
         assert_eq!(cnt, 100000, "The cache should contain 100000 paths");
         assert_eq!(cache_shortened_result.len(), cnt);
-    }
-
-    #[cfg(not(debug_assertions))]
-    #[test]
-    fn test_fuzzy_search_speed() {
-        // Arrange
-        let workspace_paths = vec![
-            PathBuf::from("home").join("user").join("repo1"),
-            PathBuf::from("home").join("user").join("repo2"),
-            PathBuf::from("home").join("user").join("repo3"),
-            PathBuf::from("home").join("user").join("repo4"),
-        ];
-
-        let mut paths = Vec::new();
-        for i in 0..100000 {
-            let path = workspace_paths[i % workspace_paths.len()]
-                .join(format!("dir{}", i % 1000))
-                .join(format!("dir{}", i / 1000))
-                .join(format!("file{}.ext", i));
-            paths.push(path);
-        }
-        let start_time = std::time::Instant::now();
-        let paths_str = paths.iter().map(|x| x.to_string_lossy().to_string()).collect::<Vec<_>>();
-
-        let correction_candidate = PathBuf::from("file100000")
-            .join("dir1000")
-            .join("file100000.ext")
-            .to_string_lossy()
-            .to_string();
-
-        // Act
-        let results = fuzzy_search(&correction_candidate, paths_str, 10, std::path::MAIN_SEPARATOR);
-
-        // Assert
-        let time_spent = start_time.elapsed();
-        println!("fuzzy_search took {} ms", time_spent.as_millis());
-        assert!(time_spent.as_millis() < 750, "fuzzy_search took {} ms", time_spent.as_millis());
-
-        assert_eq!(results.len(), 10, "The result should contain 10 paths");
-        println!("{:?}", results);
     }
 }

--- a/src/files_correction.rs
+++ b/src/files_correction.rs
@@ -120,6 +120,7 @@ pub fn fuzzy_search<I>(
     correction_candidate: &String,
     candidates: I,
     top_n: usize,
+    separator_first_char: char,
 ) -> Vec<String>
 where I: IntoIterator<Item = String> {
     const FILENAME_WEIGHT: i32 = 3;
@@ -132,7 +133,7 @@ where I: IntoIterator<Item = String> {
     let mut correction_candidate_length = 0;
     let mut weight = FILENAME_WEIGHT;
     for window in correction_candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-        if window[0] == std::path::MAIN_SEPARATOR {
+        if window[0] == separator_first_char {
             weight = 1;
         }
         correction_candidate_length += weight;
@@ -152,7 +153,7 @@ where I: IntoIterator<Item = String> {
         // Discount candidate's bigrams from correction candidate's ones
         let mut weight = FILENAME_WEIGHT;
         for window in candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-            if window[0] == std::path::MAIN_SEPARATOR {
+            if window[0] == separator_first_char {
                 weight = 1;
             }
             candidate_len += weight;
@@ -206,7 +207,7 @@ pub async fn correct_to_nearest_filename(
 
     if fuzzy {
         info!("fuzzy search {:?}, cache_fuzzy_arc.len={}", correction_candidate, cache_fuzzy_arc.len());
-        return fuzzy_search(correction_candidate, cache_fuzzy_arc.iter().cloned(), top_n);
+        return fuzzy_search(correction_candidate, cache_fuzzy_arc.iter().cloned(), top_n, std::path::MAIN_SEPARATOR);
     }
 
     return vec![];
@@ -252,7 +253,7 @@ pub async fn correct_to_nearest_dir_path(
         }
 
         info!("fuzzy search {:?}, dirs.len={}", correction_candidate, dirs.len());
-        return fuzzy_search(correction_candidate, dirs.iter().cloned(), top_n);
+        return fuzzy_search(correction_candidate, dirs.iter().cloned(), top_n, std::path::MAIN_SEPARATOR);
     }
     vec![]
 }
@@ -379,7 +380,7 @@ mod tests {
         let candidates = get_candidates_from_workspace_files().await;
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
 
         // Assert
         let expected_result = vec![
@@ -398,7 +399,7 @@ mod tests {
         let candidates = get_candidates_from_workspace_files().await;
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
 
         // Assert
         let expected_result = vec![
@@ -421,7 +422,7 @@ mod tests {
         ];
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
 
         // Assert
         let expected_result = vec![
@@ -572,7 +573,7 @@ mod tests {
             .to_string();
 
         // Act
-        let results = fuzzy_search(&correction_candidate, paths_str, 10);
+        let results = fuzzy_search(&correction_candidate, paths_str, 10, std::path::MAIN_SEPARATOR);
 
         // Assert
         let time_spent = start_time.elapsed();

--- a/src/files_correction.rs
+++ b/src/files_correction.rs
@@ -136,7 +136,7 @@ pub async fn correct_to_nearest_filename(
 
     if fuzzy {
         info!("fuzzy search {:?}, cache_fuzzy_arc.len={}", correction_candidate, cache_fuzzy_arc.len());
-        return fuzzy_search(correction_candidate, cache_fuzzy_arc.iter().cloned(), top_n, std::path::MAIN_SEPARATOR);
+        return fuzzy_search(correction_candidate, cache_fuzzy_arc.iter().cloned(), top_n, &['/', '\\']);
     }
 
     return vec![];
@@ -182,7 +182,7 @@ pub async fn correct_to_nearest_dir_path(
         }
 
         info!("fuzzy search {:?}, dirs.len={}", correction_candidate, dirs.len());
-        return fuzzy_search(correction_candidate, dirs.iter().cloned(), top_n, std::path::MAIN_SEPARATOR);
+        return fuzzy_search(correction_candidate, dirs.iter().cloned(), top_n, &['/', '\\']);
     }
     vec![]
 }

--- a/src/fuzzy_search.rs
+++ b/src/fuzzy_search.rs
@@ -8,7 +8,7 @@ pub fn fuzzy_search<I>(
 ) -> Vec<String>
 where I: IntoIterator<Item = String> {
     const FILENAME_WEIGHT: i32 = 3;
-    const DISTANCE_THRESHOLD: f64 = 0.40;
+    const COMPLETELTY_DROP_DISTANCE: f64 = 0.40;
     const EXCESS_WEIGHT: f64 = 3.0;
 
     let mut correction_bigram_count: HashMap<(char, char), i32> = HashMap::new();
@@ -58,7 +58,7 @@ where I: IntoIterator<Item = String> {
 
         let distance = (missing_count as f64 + excess_count as f64 * EXCESS_WEIGHT) /
             (correction_candidate_length as f64 + (candidate_len as f64) * EXCESS_WEIGHT);
-        if distance < DISTANCE_THRESHOLD {
+        if distance < COMPLETELTY_DROP_DISTANCE {
             top_n_candidates.push((candidate, distance));
             top_n_candidates
                 .sort_by(|a, b| a.1.partial_cmp(&b.1)

--- a/src/fuzzy_search.rs
+++ b/src/fuzzy_search.rs
@@ -4,7 +4,7 @@ pub fn fuzzy_search<I>(
     correction_candidate: &String,
     candidates: I,
     top_n: usize,
-    separator_first_char: char,
+    separator_chars: &[char],
 ) -> Vec<String>
 where I: IntoIterator<Item = String> {
     const FILENAME_WEIGHT: i32 = 3;
@@ -17,7 +17,7 @@ where I: IntoIterator<Item = String> {
     let mut correction_candidate_length = 0;
     let mut weight = FILENAME_WEIGHT;
     for window in correction_candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-        if window[0] == separator_first_char {
+        if separator_chars.contains(&window[0]) {
             weight = 1;
         }
         correction_candidate_length += weight;
@@ -37,7 +37,7 @@ where I: IntoIterator<Item = String> {
         // Discount candidate's bigrams from correction candidate's ones
         let mut weight = FILENAME_WEIGHT;
         for window in candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
-            if window[0] == separator_first_char {
+            if separator_chars.contains(&window[0]) {
                 weight = 1;
             }
             candidate_len += weight;
@@ -106,7 +106,7 @@ mod tests {
         let candidates = get_candidates_from_workspace_files().await;
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, &['/', '\\']);
 
         // Assert
         let expected_result = vec![
@@ -125,7 +125,7 @@ mod tests {
         let candidates = get_candidates_from_workspace_files().await;
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, &['/', '\\']);
 
         // Assert
         let expected_result = vec![
@@ -148,7 +148,7 @@ mod tests {
         ];
 
         // Act
-        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, &['/', '\\']);
 
         // Assert
         let expected_result = vec![
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(sorted_result, sorted_expected, "The result should contain the expected paths in any order, found {:?} instead", result);
     }
 
-    #[cfg(not(debug_assertions))]
+    // #[cfg(not(debug_assertions))]
     #[test]
     fn test_fuzzy_search_speed() {
         // Arrange
@@ -194,7 +194,7 @@ mod tests {
             .to_string();
 
         // Act
-        let results = fuzzy_search(&correction_candidate, paths_str, 10, std::path::MAIN_SEPARATOR);
+        let results = fuzzy_search(&correction_candidate, paths_str, 10, &['/', '\\']);
 
         // Assert
         let time_spent = start_time.elapsed();

--- a/src/fuzzy_search.rs
+++ b/src/fuzzy_search.rs
@@ -1,0 +1,207 @@
+use std::collections::HashMap;
+
+pub fn fuzzy_search<I>(
+    correction_candidate: &String,
+    candidates: I,
+    top_n: usize,
+    separator_first_char: char,
+) -> Vec<String>
+where I: IntoIterator<Item = String> {
+    const FILENAME_WEIGHT: i32 = 3;
+    const DISTANCE_THRESHOLD: f64 = 0.40;
+    const EXCESS_WEIGHT: f64 = 3.0;
+
+    let mut correction_bigram_count: HashMap<(char, char), i32> = HashMap::new();
+
+    // Count bigrams of correction candidate
+    let mut correction_candidate_length = 0;
+    let mut weight = FILENAME_WEIGHT;
+    for window in correction_candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
+        if window[0] == separator_first_char {
+            weight = 1;
+        }
+        correction_candidate_length += weight;
+        *correction_bigram_count
+            .entry((window[0], window[1]))
+            .or_insert(0) += weight;
+    }
+
+    let mut top_n_candidates = Vec::new();
+
+    for candidate in candidates {
+        let mut missing_count: i32 = 0;
+        let mut excess_count = 0;
+        let mut candidate_len = 0;
+        let mut bigram_count = correction_bigram_count.clone();
+
+        // Discount candidate's bigrams from correction candidate's ones
+        let mut weight = FILENAME_WEIGHT;
+        for window in candidate.to_lowercase().chars().collect::<Vec<_>>().windows(2).rev() {
+            if window[0] == separator_first_char {
+                weight = 1;
+            }
+            candidate_len += weight;
+            if let Some(entry) = bigram_count.get_mut(&(window[0], window[1])) {
+                *entry -= weight;
+            } else {
+                missing_count += weight;
+            }
+        }
+
+        for (&_, &count) in bigram_count.iter() {
+            if count > 0 {
+                excess_count += count;
+            } else {
+                missing_count += -count;
+            }
+        }
+
+        let distance = (missing_count as f64 + excess_count as f64 * EXCESS_WEIGHT) /
+            (correction_candidate_length as f64 + (candidate_len as f64) * EXCESS_WEIGHT);
+        if distance < DISTANCE_THRESHOLD {
+            top_n_candidates.push((candidate, distance));
+            top_n_candidates
+                .sort_by(|a, b| a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal));
+            if top_n_candidates.len() > top_n {
+                top_n_candidates.pop();
+            }
+        }
+    }
+
+    top_n_candidates.into_iter().map(|x| x.0).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use crate::files_in_workspace::retrieve_files_in_workspace_folders;
+
+    async fn get_candidates_from_workspace_files() -> Vec<String> {
+        let proj_folders = vec![PathBuf::from(".").canonicalize().unwrap()];
+        let proj_folder = &proj_folders[0];
+
+        let workspace_files = retrieve_files_in_workspace_folders(proj_folders.clone()).await;
+
+        workspace_files
+            .iter()
+            .filter_map(|path| {
+                let relative_path = path.strip_prefix(proj_folder)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .to_string();
+
+                    Some(relative_path)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_fuzzy_search_finds_frog_py() {
+        // Arrange
+        let correction_candidate = "frog.p".to_string();
+        let top_n = 1;
+
+        let candidates = get_candidates_from_workspace_files().await;
+
+        // Act
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+
+        // Assert
+        let expected_result = vec![
+            PathBuf::from("tests").join("emergency_frog_situation").join("frog.py").to_string_lossy().to_string(),
+        ];
+
+        assert_eq!(result, expected_result, "It should find the proper frog.py, found {:?} instead", result);
+    }
+
+    #[tokio::test]
+    async fn test_fuzzy_search_path_helps_finding_file() {
+        // Arrange
+        let correction_candidate = PathBuf::from("emergency_frog_situation").join("wo").to_string_lossy().to_string();
+        let top_n = 1;
+
+        let candidates = get_candidates_from_workspace_files().await;
+
+        // Act
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+
+        // Assert
+        let expected_result = vec![
+            PathBuf::from("tests").join("emergency_frog_situation").join("work_day.py").to_string_lossy().to_string(),
+        ];
+
+        assert_eq!(result, expected_result, "It should find the proper file (work_day.py), found {:?} instead", result);
+    }
+
+    #[tokio::test]
+    async fn test_fuzzy_search_filename_weights_more_than_path() {
+        // Arrange
+        let correction_candidate = "my_file.ext".to_string();
+        let top_n = 2;
+
+        let candidates = vec![
+            PathBuf::from("my_library").join("implementation").join("my_file.ext").to_string_lossy().to_string(),
+            PathBuf::from("my_library").join("my_file.ext").to_string_lossy().to_string(),
+            PathBuf::from("another_file.ext").to_string_lossy().to_string(),
+        ];
+
+        // Act
+        let result = fuzzy_search(&correction_candidate, candidates, top_n, std::path::MAIN_SEPARATOR);
+
+        // Assert
+        let expected_result = vec![
+            PathBuf::from("my_library").join("my_file.ext").to_string_lossy().to_string(),
+            PathBuf::from("my_library").join("implementation").join("my_file.ext").to_string_lossy().to_string(),
+        ];
+
+        let mut sorted_result = result.clone();
+        let mut sorted_expected = expected_result.clone();
+
+        sorted_result.sort();
+        sorted_expected.sort();
+
+        assert_eq!(sorted_result, sorted_expected, "The result should contain the expected paths in any order, found {:?} instead", result);
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn test_fuzzy_search_speed() {
+        // Arrange
+        let workspace_paths = vec![
+            PathBuf::from("home").join("user").join("repo1"),
+            PathBuf::from("home").join("user").join("repo2"),
+            PathBuf::from("home").join("user").join("repo3"),
+            PathBuf::from("home").join("user").join("repo4"),
+        ];
+
+        let mut paths = Vec::new();
+        for i in 0..100000 {
+            let path = workspace_paths[i % workspace_paths.len()]
+                .join(format!("dir{}", i % 1000))
+                .join(format!("dir{}", i / 1000))
+                .join(format!("file{}.ext", i));
+            paths.push(path);
+        }
+        let start_time = std::time::Instant::now();
+        let paths_str = paths.iter().map(|x| x.to_string_lossy().to_string()).collect::<Vec<_>>();
+
+        let correction_candidate = PathBuf::from("file100000")
+            .join("dir1000")
+            .join("file100000.ext")
+            .to_string_lossy()
+            .to_string();
+
+        // Act
+        let results = fuzzy_search(&correction_candidate, paths_str, 10, std::path::MAIN_SEPARATOR);
+
+        // Assert
+        let time_spent = start_time.elapsed();
+        println!("fuzzy_search took {} ms", time_spent.as_millis());
+        assert!(time_spent.as_millis() < 750, "fuzzy_search took {} ms", time_spent.as_millis());
+
+        assert_eq!(results.len(), 10, "The result should contain 10 paths");
+        println!("{:?}", results);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod single_shot_commands;
 mod file_filter;
 mod files_in_workspace;
 mod files_in_jsonl;
+mod fuzzy_search;
 mod files_correction;
 mod vecdb;
 mod ast;

--- a/src/tools/tool_ast_definition.rs
+++ b/src/tools/tool_ast_definition.rs
@@ -112,11 +112,8 @@ pub async fn there_are_definitions_with_similar_names_though(
     ast_index: Arc<AMutex<AstDB>>,
     symbol: &str,
 ) -> String {
-    let fuzzy_matches: Vec<String> = crate::ast::ast_db::definition_paths_fuzzy(ast_index.clone(), symbol)
-        .await
-        .into_iter()
-        .take(20)
-        .collect();
+    let fuzzy_matches: Vec<String> = crate::ast::ast_db::definition_paths_fuzzy(ast_index.clone(), symbol, 20, 5000)
+        .await;
 
     let tool_message = if fuzzy_matches.is_empty() {
         let counters = fetch_counters(ast_index).await;


### PR DESCRIPTION
* Modified AST fuzzy search, to make it more permissive to errors, using same distance metric than the fuzzy search to find files + prefix searching in the database.
* Changed fuzzy_search to a separate file since it's used in several places now.
* Fixed search for both \ and / for paths.