### PR TITLE
patch-apply-all handler

### DIFF
--- a/src/http/routers/v1.rs
+++ b/src/http/routers/v1.rs
@@ -29,7 +29,7 @@ use crate::http::routers::v1::status::handle_v1_rag_status;
 use crate::http::routers::v1::customization::handle_v1_customization;
 use crate::http::routers::v1::customization::handle_v1_config_path;
 use crate::http::routers::v1::gui_help_handlers::handle_v1_fullpath;
-use crate::http::routers::v1::patch::handle_v1_patch_single_file_from_ticket;
+use crate::http::routers::v1::patch::{handle_v1_patch_apply_all, handle_v1_patch_single_file_from_ticket};
 use crate::http::routers::v1::subchat::{handle_v1_subchat, handle_v1_subchat_single};
 use crate::http::routers::v1::sync_files::handle_v1_sync_files_extract_tar;
 use crate::http::routers::v1::system_prompt::handle_v1_system_prompt;
@@ -122,7 +122,7 @@ pub fn make_v1_router() -> Router {
         .route("/docker-container-action", telemetry_post!(handle_v1_docker_container_action))
 
         .route("/patch-single-file-from-ticket", telemetry_post!(handle_v1_patch_single_file_from_ticket))
-        // .route("/patch-apply-all", telemetry_post!(handle_v1_patch_single_file_from_ticket))
+        .route("/patch-apply-all", telemetry_post!(handle_v1_patch_apply_all))
 
         // experimental
         .route("/get-dashboard-plots", telemetry_get!(get_dashboard_plots))

--- a/src/http/routers/v1/patch.rs
+++ b/src/http/routers/v1/patch.rs
@@ -4,6 +4,7 @@ use axum::Extension;
 use axum::http::{Response, StatusCode};
 use hashbrown::HashMap;
 use hyper::Body;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock as ARwLock, Mutex as AMutex};
 use crate::at_commands::at_commands::AtCommandsContext;
@@ -12,8 +13,9 @@ use crate::custom_error::ScratchError;
 use crate::diffs::{ApplyDiffResult, correct_and_validate_chunks, read_files_n_apply_diff_chunks, unwrap_diff_apply_outputs, ApplyDiffOutput, ApplyDiffUnwrapped};
 use crate::global_context::GlobalContext;
 use crate::http::routers::v1::chat::deserialize_messages_from_post;
-use crate::tools::tool_patch_aux::tickets_parsing::{get_and_correct_active_tickets, get_tickets_from_messages};
+use crate::tools::tool_patch_aux::tickets_parsing::{correct_and_validate_active_ticket, get_and_correct_active_tickets, get_tickets_from_messages, TicketToApply};
 use crate::tools::tool_patch::process_tickets;
+use crate::tools::tool_patch_aux::diff_apply::diff_apply;
 use crate::tools::tool_patch_aux::postprocessing_utils::fill_out_already_applied_status;
 use crate::tools::tools_execute::unwrap_subchat_params;
 
@@ -24,10 +26,20 @@ pub struct PatchPost {
     pub ticket_ids: Vec<String>,
 }
 
+#[derive(Deserialize)]
+pub struct PatchApplyAllPost {
+    pub messages: Vec<serde_json::Value>,
+}
+
 #[derive(Serialize)]
 pub struct PatchResponse {
     state: Vec<ApplyDiffUnwrapped>,
     results: Vec<ApplyDiffResult>,
+    chunks: Vec<DiffChunk>,
+}
+
+#[derive(Serialize)]
+pub struct PatchApplyAllResponse {
     chunks: Vec<DiffChunk>,
 }
 
@@ -130,6 +142,82 @@ pub async fn handle_v1_patch_single_file_from_ticket(
             results,
             state: apply_outputs, 
             chunks: diff_chunks 
+        }).unwrap()))
+        .unwrap())
+}
+
+pub async fn handle_v1_patch_apply_all(
+    Extension(global_context): Extension<Arc<ARwLock<GlobalContext>>>,
+    body_bytes: hyper::body::Bytes,
+) -> axum::response::Result<Response<Body>, ScratchError> {
+    let post = serde_json::from_slice::<PatchApplyAllPost>(&body_bytes)
+        .map_err(|e| ScratchError::new(StatusCode::UNPROCESSABLE_ENTITY, format!("JSON problem: {}", e)))?;
+    let messages = deserialize_messages_from_post(&post.messages)?;
+
+    let ccx = Arc::new(AMutex::new(AtCommandsContext::new(
+        global_context.clone(),
+        8096,
+        10,
+        false,
+        messages,
+        "".to_string(),
+        false,
+    ).await));
+    let params = unwrap_subchat_params(ccx.clone(), "patch").await.map_err(|e| {
+        ScratchError::new(StatusCode::BAD_REQUEST, format!("Failed to unwrap subchat params: {}", e))
+    })?;
+    {
+        let mut ccx_lock = ccx.lock().await;
+        ccx_lock.n_ctx = params.subchat_n_ctx;
+    }
+
+    // leave only the latest ticket for each file
+    let all_tickets = get_tickets_from_messages(ccx.clone()).await;
+    let mut filename_by_ticket: HashMap<String, TicketToApply> = HashMap::new();
+    for ticket in all_tickets.values() {
+        if let Some(el) = filename_by_ticket.get(&ticket.filename_before) {
+            if ticket.message_idx <= el.message_idx {
+                continue
+            } else {
+                filename_by_ticket.remove(&ticket.filename_before);
+            }
+        }
+        let mut ticket = ticket.clone();
+        correct_and_validate_active_ticket(global_context.clone(), &mut ticket).await.map_err(|e|
+            ScratchError::new(StatusCode::UNPROCESSABLE_ENTITY, format!("Invalid ticket: {e}"))
+        )?;
+        filename_by_ticket.insert(ticket.filename_before.clone(), ticket);
+    }
+    let mut active_tickets = filename_by_ticket.values().cloned().collect::<Vec<_>>();
+    let active_indices = active_tickets.iter().map(|ticket| ticket.id.clone()).collect::<Vec<_>>();
+
+    let mut usage = ChatUsage { ..Default::default() };
+    let diff_chunks_maybe = process_tickets(
+        ccx.clone(),
+        &mut active_tickets,
+        active_indices,
+        &params,
+        &"patch_123".to_string(),
+        &mut usage,
+    ).await;
+    if !active_tickets.is_empty() {
+        let bad_ticket_ids = active_tickets.iter().map(|ticket| ticket.id.clone()).join(", ");
+        return Err(ScratchError::new(
+            StatusCode::UNPROCESSABLE_ENTITY, format!("Couldn't process some of the tickets: {bad_ticket_ids}"
+            )))
+    }
+    let mut diff_chunks = diff_chunks_maybe.map_err(|(e, _)|
+        ScratchError::new(StatusCode::UNPROCESSABLE_ENTITY, e)
+    )?;
+    diff_apply(global_context.clone(), &mut diff_chunks).await.map_err(|err| ScratchError::new(
+        StatusCode::UNPROCESSABLE_ENTITY, format!("Couldn't apply the diff: {err}"))
+    )?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string_pretty(&PatchApplyAllResponse {
+            chunks: diff_chunks
         }).unwrap()))
         .unwrap())
 }


### PR DESCRIPTION
- Introduce the 'handle_v1_patch_apply_all' function to handle requests for applying all patches.
- Add a new API route '/patch-apply-all' for the above handler.
- Update ticket parsing to include message index tracking.
- Include additional structs 'PatchApplyAllPost' and 'PatchApplyAllResponse' for request and response payloads.