### PR TITLE
Extra stop tokens in FillInTheMiddleScratchpad

### DIFF
--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -210,6 +210,7 @@ pub const KNOWN_MODELS: &str = r####"
                     "fim_suffix": "<|fim_suffix|>",
                     "fim_middle": "<|fim_middle|>",
                     "eot": "<|endoftext|>",
+                    "extra_stop_tokens": ["<|repo_name|>", "<|file_sep|>"],
                     "context_format": "qwen2.5",
                     "rag_ratio": 0.5
                 }

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -161,7 +161,7 @@ fn prepare_cursor_file(
 ) -> Result<(String, usize, (usize, usize)), String> {
     let mut output_lines: VecDeque<String> = VecDeque::new();
     let mut tokens_used: usize = 0;
-    let mut line_idx_offset: usize = 1;
+    let mut line_idx_offset: i32 = 1;
 
     if let Some(line) = file_text.line(cursor_pos.line as usize).as_str() {
         output_lines.push_front(line.to_string());

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -161,7 +161,7 @@ fn prepare_cursor_file(
 ) -> Result<(String, usize, (usize, usize)), String> {
     let mut output_lines: VecDeque<String> = VecDeque::new();
     let mut tokens_used: usize = 0;
-    let mut line_idx_offset: i32 = 1;
+    let mut line_idx_offset: usize = 1;
 
     if let Some(line) = file_text.line(cursor_pos.line as usize).as_str() {
         output_lines.push_front(line.to_string());


### PR DESCRIPTION
- Introduce `extra_stop_tokens` field to hold additional stop tokens.
- Modify `_cut_result` to handle new extra stop tokens.
- Ensure `extra_stop_tokens` are included in stop list for sampling parameters.