### PR TITLE
Project summary chat module

### DIFF
--- a/src/http/routers/v1.rs
+++ b/src/http/routers/v1.rs
@@ -18,7 +18,7 @@ use crate::http::routers::v1::at_commands::{handle_v1_command_completion, handle
 use crate::http::routers::v1::at_tools::{handle_v1_tools, handle_v1_tools_check_if_confirmation_needed, handle_v1_tools_execute};
 use crate::http::routers::v1::caps::handle_v1_caps;
 use crate::http::routers::v1::caps::handle_v1_ping;
-use crate::http::routers::v1::chat::{handle_v1_chat, handle_v1_chat_completions, handle_v1_chat_configuration};
+use crate::http::routers::v1::chat::{handle_v1_chat, handle_v1_chat_completions, handle_v1_chat_configuration, handle_v1_chat_project_summary};
 use crate::http::routers::v1::chat_based_handlers::handle_v1_commit_message_from_diff;
 use crate::http::routers::v1::dashboard::get_dashboard_plots;
 use crate::http::routers::v1::docker::{handle_v1_docker_container_action, handle_v1_docker_container_list};
@@ -86,6 +86,7 @@ pub fn make_v1_router() -> Router {
         .route("/chat", telemetry_post!(handle_v1_chat))
         .route("/chat/completions", telemetry_post!(handle_v1_chat_completions))  // standard
         .route("/chat-configuration", telemetry_post!(handle_v1_chat_configuration))
+        .route("/chat-project-summary", telemetry_post!(handle_v1_chat_project_summary))
 
         .route("/telemetry-network", telemetry_post!(handle_v1_telemetry_network))
         .route("/snippet-accepted", telemetry_post!(handle_v1_snippet_accepted))

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -21,6 +21,7 @@ pub mod process_io_utils;
 pub mod docker;
 pub mod sessions;
 pub mod config_chat;
+pub mod project_summary_chat;
 pub mod yaml_schema;
 pub mod setting_up_integrations;
 pub mod running_integrations;

--- a/src/integrations/project_summary_chat.rs
+++ b/src/integrations/project_summary_chat.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+use std::fs;
+use tokio::sync::RwLock as ARwLock;
+use std::collections::HashMap;
+use itertools::Itertools;
+use crate::global_context::GlobalContext;
+use crate::call_validation::{ChatContent, ChatMessage, ContextFile};
+use crate::scratchpads::chat_utils_prompts::system_prompt_add_workspace_info;
+
+pub async fn mix_config_messages(
+    gcx: Arc<ARwLock<GlobalContext>>,
+    messages: &mut Vec<ChatMessage>,
+    current_config_file: &String,
+) {
+    let custom: crate::yaml_configs::customization_loader::CustomizationYaml = match crate::yaml_configs::customization_loader::load_customization(gcx.clone(), true).await {
+        Ok(x) => x,
+        Err(why) => {
+            tracing::error!("Failed to load customization.yaml, will use compiled-in default for the configurator system prompt:\n{:?}", why);
+            crate::yaml_configs::customization_loader::load_and_mix_with_users_config(
+                crate::yaml_configs::customization_compiled_in::COMPILED_IN_INITIAL_USER_YAML,
+                "", "", true, true, &HashMap::new(),
+            ).unwrap()
+        }
+    };
+    let sp: &crate::yaml_configs::customization_loader::SystemPrompt = custom.system_prompts.get("project_summary").unwrap();
+    let mut sp_text = sp.text.clone();
+    sp_text = system_prompt_add_workspace_info(gcx.clone(), &sp_text.replace("%CONFIG_PATH%", current_config_file)).await;
+    
+    let available_integrations = crate::integrations::setting_up_integrations::integrations_all_with_icons(
+        gcx.clone()
+    ).await;
+    let mut available_integrations_text: String = "Choose tools from this list:\n".to_string();
+    for integration in available_integrations.integrations.iter().map(|x| x.integr_name.clone()).unique() {
+        available_integrations_text.push_str(&format!("- {}\n", integration))
+    }
+    
+    if messages.is_empty() {
+        messages.push(ChatMessage {
+            role: "system".to_string(),
+            content: ChatContent::SimpleText(sp_text),
+            tool_calls: None,
+            tool_call_id: String::new(),
+            usage: None,
+        });
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: ChatContent::SimpleText(available_integrations_text),
+            tool_calls: None,
+            tool_call_id: String::new(),
+            usage: None,
+        });
+    };
+}
+

--- a/src/yaml_configs/customization_compiled_in.rs
+++ b/src/yaml_configs/customization_compiled_in.rs
@@ -173,7 +173,6 @@ PROMPT_PROJECT_SUMMARY: |
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
-  %PROJECT_INFO%
 
   Plan to follow:
   1. Explore the Project Structure:

--- a/src/yaml_configs/customization_compiled_in.rs
+++ b/src/yaml_configs/customization_compiled_in.rs
@@ -68,6 +68,7 @@ PROMPT_EXPLORATION_TOOLS: |
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
+  %PROJECT_INFO%
 
   Good thinking strategy for the answers: is it a question related to the current project?
   Yes => collect the necessary context using search, definition and references tools calls in parallel, or just do what the user tells you.
@@ -85,6 +86,7 @@ PROMPT_AGENTIC_TOOLS: |
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
+  %PROJECT_INFO%
 
   Good practice using knowledge(): it's the key to successfully completing complex tasks the user might present you with. This
   tool has access to external data, including successful trajectories you can use to accomplish your task by analogy. The knowledge()
@@ -123,6 +125,7 @@ PROMPT_CONFIGURATOR: |
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
+  %PROJECT_INFO%
 
   The integration config format is the following YAML:
   ```
@@ -170,6 +173,7 @@ PROMPT_PROJECT_SUMMARY: |
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
+  %PROJECT_INFO%
 
   Plan to follow:
   1. Explore the Project Structure:

--- a/src/yaml_configs/customization_compiled_in.rs
+++ b/src/yaml_configs/customization_compiled_in.rs
@@ -162,6 +162,31 @@ PROMPT_CONFIGURATOR: |
   - ask the user if they want to change anything
   - write updated configs using 📍REWRITE_WHOLE_FILE
 
+PROMPT_PROJECT_SUMMARY: |
+  You are Refact Agent, a coding assistant. 
+  Your task is to make a summary of the project you're working with and also choose tools from the given list which could be useful to work with the project.
+  Select only those tools which are really using inside the project.
+
+  %PROMPT_PINS%
+  %WORKSPACE_INFO%
+
+  Plan to follow:
+  1. Look at the current project by calling tree().
+  2. After investigating the project's tree, call cat() to look inside documentation (especially *.md) files like README.md.
+  2. Also use cat() to look inside configuration files like Cargo.toml, package.json, requirements.txt, ....
+  3. Write everything you've gathered about the project and list tools which could be useful 
+  4. Ask the user if they want to change anything
+  5. Write the project summary and tools list in the YAML format using 📍REWRITE_WHOLE_FILE
+
+  The project summary config format is the following YAML:
+  ```
+  project_summary:
+    <a short text summary of the project>
+  recommended_tools:
+    - tool_name: <tool_name_1>
+    - tool_name: <tool_name_2>
+  ```
+  Put the generated config to this path: %CONFIG_PATH%
 
 system_prompts:
   default:
@@ -176,7 +201,7 @@ system_prompts:
     text: "%PROMPT_CONFIGURATOR%"
     show: never
   project_summary:
-    text: "TBD"
+    text: "%PROMPT_PROJECT_SUMMARY%"
     show: never
 
 

--- a/src/yaml_configs/customization_compiled_in.rs
+++ b/src/yaml_configs/customization_compiled_in.rs
@@ -166,17 +166,25 @@ PROMPT_PROJECT_SUMMARY: |
   You are Refact Agent, a coding assistant. 
   Your task is to make a summary of the project you're working with and also choose tools from the given list which could be useful to work with the project.
   Select only those tools which are really using inside the project.
+  %AVAILABLE_INTEGRATIONS%
 
   %PROMPT_PINS%
   %WORKSPACE_INFO%
 
   Plan to follow:
-  1. Look at the current project by calling tree().
-  2. After investigating the project's tree, call cat() to look inside documentation (especially *.md) files like README.md.
-  2. Also use cat() to look inside configuration files like Cargo.toml, package.json, requirements.txt, ....
-  3. Write everything you've gathered about the project and list tools which could be useful 
-  4. Ask the user if they want to change anything
-  5. Write the project summary and tools list in the YAML format using 📍REWRITE_WHOLE_FILE
+  1. Explore the Project Structure:
+    - Use the tree() command to display the directory structure of the current project.
+  2. Investigate Key Files:
+    - Use cat() to review content in important documentation files, such as README.md and other .md files.
+    - Use cat() to examine configuration files, including Cargo.toml, package.json, requirements.txt, etc.
+  3. Summarize Findings:
+    - Write a detailed summary of the gathered information about the project.
+    - Compile a list of tools that might be useful for working on the project.
+  4. Get User Feedback:
+    - Ask the user if they would like to make changes or updates to any part of the project setup or tool list.
+  5. Prepare YAML Output:
+    - Organize the project summary and tools list in YAML format.
+    - Use the tag 📍REWRITE_WHOLE_FILE to indicate the final structured YAML content.
 
   The project summary config format is the following YAML:
   ```
@@ -187,6 +195,7 @@ PROMPT_PROJECT_SUMMARY: |
     - tool_name: <tool_name_2>
   ```
   Put the generated config to this path: %CONFIG_PATH%
+  Strictly follow the plan!
 
 system_prompts:
   default:


### PR DESCRIPTION
Introduce `project_summary_chat` module and integrate it with the existing chat system. Implement asynchronous function `mix_config_messages` to load project-specific configurations and available integration tools, adding them to chat messages. Update HTTP router to include a new endpoint `/chat-project-summary` for handling project summaries. Add default prompt configuration for project summaries in `customization_compiled_in.rs`. This enhancement allows generating a concise project overview and identifying suitable tools within the project's context.