### PR TITLE
Trajectories downloading

### DIFF
--- a/python_binding_and_cmdline/refact/chat_client.py
+++ b/python_binding_and_cmdline/refact/chat_client.py
@@ -400,13 +400,14 @@ async def diff_apply(
             return await _better_response_json(response)
 
 
-async def mem_add(base_url: str, mem_type: str, goal: str, project: str, payload: str) -> Dict[str, Any]:
+async def mem_add(base_url: str, mem_type: str, goal: str, project: str, payload: str, origin: str = "local-committed") -> Dict[str, Any]:
     url = f"{base_url}/mem-add"
     data = {
         "mem_type": mem_type,
         "goal": goal,
         "project": project,
-        "payload": payload
+        "payload": payload,
+        "origin": origin,
     }
     async with aiohttp.ClientSession() as session:
         async with session.post(url, json=data) as response:

--- a/src/http/routers/v1/handlers_memdb.rs
+++ b/src/http/routers/v1/handlers_memdb.rs
@@ -15,7 +15,8 @@ struct MemAddRequest {
     mem_type: String,
     goal: String,
     project: String,
-    payload: String,   // TODO: upgrade to serde_json::Value
+    payload: String,
+    origin: String,   // TODO: upgrade to serde_json::Value
 }
 
 #[derive(Deserialize)]
@@ -54,7 +55,7 @@ pub async fn handle_mem_add(
         &post.goal,
         &post.project,
         &post.payload,
-        None
+        &post.origin
     ).await.map_err(|e| {
         ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
     })?;

--- a/src/http/routers/v1/handlers_memdb.rs
+++ b/src/http/routers/v1/handlers_memdb.rs
@@ -53,7 +53,8 @@ pub async fn handle_mem_add(
         &post.mem_type,
         &post.goal,
         &post.project,
-        &post.payload
+        &post.payload,
+        None
     ).await.map_err(|e| {
         ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
     })?;

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -124,7 +124,7 @@ impl MemoriesDatabase {
         Ok(())
     }
 
-    pub fn permdb_add(&self, mem_type: &str, goal: &str, project: &str, payload: &str) -> Result<String, String> {
+    pub fn permdb_add(&self, mem_type: &str, goal: &str, project: &str, payload: &str, memid: Option<String>) -> Result<String, String> {
         fn generate_memid() -> String {
             rand::thread_rng()
                 .sample_iter(&rand::distributions::Uniform::new(0, 16))
@@ -132,14 +132,13 @@ impl MemoriesDatabase {
                 .map(|x| format!("{:x}", x))
                 .collect()
         }
-
+        let memid_str = memid.unwrap_or(generate_memid());
         let conn = self.conn.lock();
-        let memid = generate_memid();
         conn.execute(
             "INSERT INTO memories (memid, m_type, m_goal, m_project, m_payload) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![memid, mem_type, goal, project, payload],
+            params![memid_str, mem_type, goal, project, payload],
         ).map_err(|e| e.to_string())?;
-        Ok(memid)
+        Ok(memid_str)
     }
 
     pub fn permdb_erase(&self, memid: &str) -> Result<usize, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ mod privacy;
 mod privacy_compiled_in;
 mod git;
 mod agentic;
-
+mod trajectories;
 
 #[tokio::main]
 async fn main() {

--- a/src/trajectories.rs
+++ b/src/trajectories.rs
@@ -1,0 +1,118 @@
+use std::collections::HashSet;
+use crate::global_context::GlobalContext;
+use crate::vecdb::vdb_highlev::{memories_add, memories_block_until_vectorized, memories_select_all};
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::RwLock as ARwLock;
+use tracing::info;
+use chrono::{NaiveDateTime, Utc};
+
+static URL: &str = "https://www.smallcloud.ai/v1/trajectory-get-all";
+static TRAJECTORIES_STATUS_FILENAME: &str = "trajectories_last_update";
+static TRAJECTORIES_UPDATE_EACH_N_DAYS: i64 = 7;
+
+
+async fn save_last_download_time(gcx: Arc<ARwLock<GlobalContext>>) -> Result<(), String> {
+    let cache_dir = gcx.read().await.cache_dir.clone();
+    let now = Utc::now().naive_utc();
+    let now_str = now.format("%Y-%m-%d %H:%M:%S").to_string();
+    let file_path = cache_dir.join(TRAJECTORIES_STATUS_FILENAME);
+    tokio::fs::write(file_path, now_str).await.map_err(|x| x.to_string())
+}
+
+async fn is_time_to_download_trajectories(gcx: Arc<ARwLock<GlobalContext>>) -> Result<bool, String> {
+    let cache_dir = gcx.read().await.cache_dir.clone();
+    let file_path = cache_dir.join(TRAJECTORIES_STATUS_FILENAME);
+    let last_download_time = match tokio::fs::read_to_string(file_path).await {
+        Ok(time_str) => {
+            NaiveDateTime::parse_from_str(&time_str, "%Y-%m-%d %H:%M:%S")
+                .map_err(|x| x.to_string())?
+        }
+        Err(_) => {
+            return Ok(true);
+        }
+    };
+    let now = Utc::now().naive_utc();
+    let duration_since_last_download = now.signed_duration_since(last_download_time);
+    Ok(duration_since_last_download.num_days() >= TRAJECTORIES_UPDATE_EACH_N_DAYS)
+}
+
+pub async fn try_to_download_trajectories(gcx: Arc<ARwLock<GlobalContext>>) -> Result<(), String> {
+    if !is_time_to_download_trajectories(gcx.clone()).await? {
+        return Ok(());
+    }
+    
+    let (vec_db, api_key) = {
+        let gcx_locked = gcx.read().await;
+        (
+            gcx_locked.vec_db.clone(),
+            gcx_locked.cmdline.api_key.clone(),
+        )
+    };
+    if vec_db.lock().await.is_none() {
+        info!("VecDb is not initialized");
+        return Ok(());
+    }
+    memories_block_until_vectorized(vec_db.clone(), 20_000).await?;
+
+    info!("starting to download trajectories...");
+    let client = reqwest::Client::new();
+    let response = client
+        .get(URL)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    let response_json: Value = response.json().await.map_err(|err| err.to_string())?;
+
+    if response_json["retcode"] != "OK" {
+        info!("failed to download trajectories: {:?}", response_json);
+        return Ok(());
+    }
+
+    let trajectories = response_json["data"].as_array().unwrap();
+    let existing_trajectories = memories_select_all(vec_db.clone())
+        .await?
+        .iter()
+        .map(|x| x.memid.clone())
+        .collect::<HashSet<String>>();
+    for trajectory in trajectories {
+        let m_memid = trajectory["memid"].as_str().ok_or("Failed to get memid")?;
+        if existing_trajectories.contains(m_memid) {
+            info!("trajectory {} already exists in the vecdb", m_memid);            
+            continue;
+        }
+        
+        let m_type = trajectory["kind"].as_str().unwrap_or("unknown");
+        let m_goal = trajectory["goal"].as_str().unwrap_or("unknown");
+        let m_project = trajectory["framework"].as_str().unwrap_or("unknown");
+        let m_payload = trajectory["payload"].as_str().unwrap_or("");
+        if m_payload.is_empty() {
+            info!("empty or no payload for the trajectory: {}, skipping it", m_memid);
+            continue;            
+        }
+        match memories_add(
+            vec_db.clone(),
+            m_type,
+            m_goal,
+            m_project,
+            m_payload,
+            Some(m_memid.to_string()),
+        ).await {
+            Ok(memid) => info!("Memory added with ID: {}", memid),
+            Err(err) => info!("Failed to add memory: {}", err),
+        }
+        info!(
+            "downloaded trajectory: memid={}, type={}, goal={}, project={}, payload={}",
+            m_memid,
+            m_type,
+            m_goal,
+            m_project,
+            crate::nicer_logs::first_n_chars(&m_payload.to_string(), 100)
+        );
+    }
+
+    info!("finished downloading trajectories");
+    save_last_download_time(gcx.clone()).await?;
+    Ok(())
+}

--- a/src/vecdb/vdb_highlev.rs
+++ b/src/vecdb/vdb_highlev.rs
@@ -194,7 +194,7 @@ pub async fn vecdb_background_reload(
         return;
     }
 
-    let trajectories_updated_once: bool = false;
+    let mut trajectories_updated_once: bool = false;
     let mut background_tasks = BackgroundTasksHolder::new(vec![]);
     loop {
         let (need_reload, consts) = do_i_need_to_reload_vecdb(gcx.clone()).await;
@@ -220,11 +220,12 @@ pub async fn vecdb_background_reload(
         }
         if !trajectories_updated_once {
             match try_to_download_trajectories(gcx.clone()).await {
-                Ok(_) => {}
+                Ok(_) => { }
                 Err(err) => {
                     error!("trajectories download failed: {}", err);
                 }
             };
+            trajectories_updated_once = true;
         } 
         tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
     }

--- a/src/vecdb/vdb_highlev.rs
+++ b/src/vecdb/vdb_highlev.rs
@@ -286,7 +286,7 @@ pub async fn memories_add(
     m_goal: &str,
     m_project: &str,
     m_payload: &str,    // TODO: upgrade to serde_json::Value
-    m_memid: Option<String>
+    m_origin: &str
 ) -> Result<String, String> {
     let (memdb, vectorizer_service) = {
         let vec_db_guard = vec_db.lock().await;
@@ -296,7 +296,7 @@ pub async fn memories_add(
 
     let memid = {
         let mut memdb_locked = memdb.lock().await;
-        let x = memdb_locked.permdb_add(m_type, m_goal, m_project, m_payload, m_memid)?;
+        let x = memdb_locked.permdb_add(m_type, m_goal, m_project, m_payload, m_origin)?;
         memdb_locked.dirty_memids.push(x.clone());
         x
     };
@@ -405,8 +405,8 @@ pub async fn memories_erase(
         vec_db.memdb.clone()
     };
 
-    let memdb_locked = memdb.lock().await;
-    let erased_cnt = memdb_locked.permdb_erase(memid)?;
+    let mut memdb_locked = memdb.lock().await;
+    let erased_cnt = memdb_locked.permdb_erase(memid).await?;
     Ok(erased_cnt)
 }
 

--- a/src/vecdb/vdb_structs.rs
+++ b/src/vecdb/vdb_structs.rs
@@ -90,6 +90,7 @@ pub struct MemoRecord {
     pub m_goal: String,
     pub m_project: String,
     pub m_payload: String,
+    pub m_origin: String,
     pub mstat_correct: f64,
     pub mstat_relevant: f64,
     pub mstat_times_used: i32,


### PR DESCRIPTION
- feat: Add optional memid parameter to permdb_add and related functions
- Updated `permdb_add` function in `MemoriesDatabase` to accept an optional `memid` parameter.
- Modified `handle_mem_add` to pass `None` for the new `memid` parameter.
- Refactored `try_to_download_trajectories` to log more detailed information and save the last download time.
- Added constants for trajectory status filename and update interval.
- Ensured `memories_add` and related functions handle the optional `memid` parameter correctly.
- Included a one-time trajectory download attempt in `vecdb_background_reload`.
- Improved logging for trajectory download process.