### PR TITLE
Confirmation

### DIFF
--- a/src/integrations/docker/integr_docker.rs
+++ b/src/integrations/docker/integr_docker.rs
@@ -324,5 +324,5 @@ available:
   when_isolated_possible: false
 confirmation:
   ask_user_default: []
-  deny_user_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
+  deny_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
 "#;

--- a/src/integrations/docker/integr_docker.rs
+++ b/src/integrations/docker/integr_docker.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::{ChatContent, ChatMessage, ContextEnum};
 use crate::global_context::GlobalContext;
-use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon};
+use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon, IntegrationConfirmation};
 use crate::tools::tools_description::Tool;
 use crate::integrations::docker::docker_ssh_tunnel_utils::{SshConfig, forward_remote_docker_if_needed};
 use crate::integrations::utils::{serialize_num_to_str, deserialize_str_to_num};
@@ -178,6 +178,10 @@ impl Tool for ToolDocker {
         command_args.insert(0, "docker".to_string());
         Ok(command_args.join(" "))
     }
+
+    fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
+        Some(self.integr_common().confirmation)
+    }
 }
 
 fn parse_command(args: &HashMap<String, Value>) -> Result<String, String>{
@@ -308,9 +312,6 @@ fields:
     f_desc: "Path to the SSH identity file to connect to remote Docker."
     f_label: "SSH Identity File"
     f_extra: true
-available:
-  on_your_laptop_possible: true
-  when_isolated_possible: false
 smartlinks:
   - sl_label: "Test"
     sl_chat:
@@ -318,4 +319,10 @@ smartlinks:
         content: |
           🔧 The docker tool should be visible now. To test the tool, list the running containers, briefly describe the containers and express
           satisfaction and relief if it works, and change nothing. If it doesn't work or the tool isn't available, go through the usual plan in the system prompt.
+available:
+  on_your_laptop_possible: true
+  when_isolated_possible: false
+confirmation:
+  ask_user_default: []
+  deny_user_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
 "#;

--- a/src/integrations/docker/integr_isolation.rs
+++ b/src/integrations/docker/integr_isolation.rs
@@ -94,4 +94,7 @@ fields:
 available:
   on_your_laptop_possible: true
   when_isolated_possible: false
+confirmation:
+  ask_user_default: []
+  deny_user_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
 "#;

--- a/src/integrations/docker/integr_isolation.rs
+++ b/src/integrations/docker/integr_isolation.rs
@@ -96,5 +96,5 @@ available:
   when_isolated_possible: false
 confirmation:
   ask_user_default: []
-  deny_user_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
+  deny_default: ["docker* rm *", "docker* rmi *", "docker* pause *", "docker* stop *", "docker* kill *"]
 "#;

--- a/src/integrations/integr_abstract.rs
+++ b/src/integrations/integr_abstract.rs
@@ -15,9 +15,9 @@ pub trait IntegrationTrait: Send + Sync {
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct IntegrationAvailable {
     #[serde(default = "default_true")]
-    pub on_your_laptop: bool,
+    pub on_your_laptop_possible: bool,
     #[serde(default = "default_true")]
-    pub when_isolated: bool,
+    pub when_isolated_possible: bool,
 }
 
 fn default_true() -> bool {
@@ -27,15 +27,15 @@ fn default_true() -> bool {
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct IntegrationConfirmation {
     #[serde(default)]
-    pub ask_user: Vec<String>,
+    pub ask_user_default: Vec<String>,
     #[serde(default)]
-    pub deny: Vec<String>,
+    pub deny_user_default: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct IntegrationCommon {
     #[serde(default)]
-    pub available: IntegrationConfirmation,
+    pub available: IntegrationAvailable,
     #[serde(default)]
-    pub confirmation: IntegrationAvailable,
+    pub confirmation: IntegrationConfirmation,
 }

--- a/src/integrations/integr_abstract.rs
+++ b/src/integrations/integr_abstract.rs
@@ -15,9 +15,9 @@ pub trait IntegrationTrait: Send + Sync {
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct IntegrationAvailable {
     #[serde(default = "default_true")]
-    pub on_your_laptop_possible: bool,
+    pub on_your_laptop: bool,
     #[serde(default = "default_true")]
-    pub when_isolated_possible: bool,
+    pub when_isolated: bool,
 }
 
 fn default_true() -> bool {
@@ -27,9 +27,9 @@ fn default_true() -> bool {
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct IntegrationConfirmation {
     #[serde(default)]
-    pub ask_user_default: Vec<String>,
+    pub ask_user: Vec<String>,
     #[serde(default)]
-    pub deny_user_default: Vec<String>,
+    pub deny: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Default)]

--- a/src/integrations/integr_chrome.rs
+++ b/src/integrations/integr_chrome.rs
@@ -15,7 +15,7 @@ use crate::call_validation::{ChatContent, ChatMessage};
 use crate::scratchpads::multimodality::MultimodalElement;
 use crate::postprocessing::pp_command_output::{CmdlineOutputFilter, output_mini_postprocessing};
 use crate::tools::tools_description::{Tool, ToolDesc, ToolParam};
-use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon};
+use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon, IntegrationConfirmation};
 
 use tokio::time::sleep;
 use chrono::DateTime;
@@ -293,6 +293,11 @@ impl Tool for ToolChrome {
             }],
             parameters_required: vec!["commands".to_string()],
         }
+    }
+
+
+    fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
+        Some(self.integr_common().confirmation)
     }
 }
 
@@ -1240,9 +1245,6 @@ fields:
     f_type: string_short
     f_desc: "Scale factor of the browser window in tablet mode."
     f_extra: true
-available:
-  on_your_laptop_possible: true
-  when_isolated_possible: true
 smartlinks:
   - sl_label: "Test"
     sl_chat:
@@ -1277,4 +1279,10 @@ docker:
         - role: "user"
           content: |
             🔧 Your job is to modify chrome config in the current file to connect through websockets to the container, use docker tool to inspect the container if needed. Current config file: %CURRENT_CONFIG%.
+available:
+  on_your_laptop_possible: true
+  when_isolated_possible: true
+confirmation:
+  ask_user_default: []
+  deny_user_default: []
 "#;

--- a/src/integrations/integr_chrome.rs
+++ b/src/integrations/integr_chrome.rs
@@ -1284,5 +1284,5 @@ available:
   when_isolated_possible: true
 confirmation:
   ask_user_default: []
-  deny_user_default: []
+  deny_default: []
 "#;

--- a/src/integrations/integr_cmdline.rs
+++ b/src/integrations/integr_cmdline.rs
@@ -323,5 +323,5 @@ available:
   when_isolated_possible: true
 confirmation:
   ask_user_default: ["*"]
-  deny_user_default: ["sudo*"]
+  deny_default: ["sudo*"]
 "#;

--- a/src/integrations/integr_cmdline.rs
+++ b/src/integrations/integr_cmdline.rs
@@ -13,7 +13,7 @@ use crate::at_commands::at_commands::AtCommandsContext;
 use crate::tools::tools_description::{ToolParam, Tool, ToolDesc};
 use crate::call_validation::{ChatMessage, ChatContent, ContextEnum};
 use crate::postprocessing::pp_command_output::{CmdlineOutputFilter, output_mini_postprocessing};
-use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon};
+use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon, IntegrationConfirmation};
 use crate::integrations::utils::{serialize_num_to_str, deserialize_str_to_num, serialize_opt_num_to_str, deserialize_str_to_opt_num};
 
 
@@ -282,6 +282,10 @@ impl Tool for ToolCmdline {
     ) -> Result<String, String> {
         let (command, _workdir) = parse_command_args(args, &self.cfg)?;
         return Ok(command);
+    }
+
+    fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
+        Some(self.integr_common().confirmation)
     }
 }
 

--- a/src/integrations/integr_cmdline_service.rs
+++ b/src/integrations/integr_cmdline_service.rs
@@ -15,7 +15,7 @@ use crate::global_context::GlobalContext;
 use crate::integrations::process_io_utils::{blocking_read_until_token_or_timeout, is_someone_listening_on_that_tcp_port};
 use crate::integrations::sessions::IntegrationSession;
 use crate::postprocessing::pp_command_output::output_mini_postprocessing;
-use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon};
+use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon, IntegrationConfirmation};
 use crate::integrations::integr_cmdline::*;
 
 
@@ -333,6 +333,10 @@ impl Tool for ToolService {
             parameters_required,
         }
     }
+
+    fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
+        Some(self.integr_common().confirmation)
+    }
 }
 
 pub const CMDLINE_SERVICE_INTEGRATION_SCHEMA: &str = r#"
@@ -363,7 +367,6 @@ fields:
     f_type: string
     f_desc: "Wait until a keyword appears in stdout or stderr at startup."
     f_placeholder: "Ready"
-
 description: |
   As opposed to command line argumenets
 
@@ -372,4 +375,7 @@ description: |
 available:
   on_your_laptop_possible: true
   when_isolated_possible: true
+confirmation:
+  ask_user_default: ["*"]
+  deny_user_default: ["sudo*"]
 "#;

--- a/src/integrations/integr_cmdline_service.rs
+++ b/src/integrations/integr_cmdline_service.rs
@@ -377,5 +377,5 @@ available:
   when_isolated_possible: true
 confirmation:
   ask_user_default: ["*"]
-  deny_user_default: ["sudo*"]
+  deny_default: ["sudo*"]
 "#;

--- a/src/integrations/integr_postgres.rs
+++ b/src/integrations/integr_postgres.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::process::Command;
 use tokio::sync::Mutex as AMutex;
-use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon};
+use crate::integrations::integr_abstract::{IntegrationTrait, IntegrationCommon, IntegrationConfirmation};
 
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -163,6 +163,10 @@ impl Tool for ToolPostgres {
         #[allow(static_mut_refs)]
         unsafe { &mut DEFAULT_USAGE }
     }
+
+    fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
+        Some(self.integr_common().confirmation)
+    }
 }
 
 // const DEFAULT_POSTGRES_INTEGRATION_YAML: &str = r#"
@@ -224,9 +228,6 @@ description: |
   On this page you can also see Docker containers with Postgres servers.
   You can ask model to create a new container with a new database for you,
   or ask model to configure the tool to use an existing container with existing database.
-available:
-  on_your_laptop_possible: true
-  when_isolated_possible: true
 smartlinks:
   - sl_label: "Test"
     sl_chat:
@@ -262,6 +263,12 @@ docker:
         - role: "user"
           content: |
             🔧 Your job is to modify postgres connection config in the current file to match the variables from the container, use docker tool to inspect the container if needed. Current config file: %CURRENT_CONFIG%.
+available:
+  on_your_laptop_possible: true
+  when_isolated_possible: true
+confirmation:
+  ask_user_default: ["psql*[!SELECT]*"]
+  deny_user_default: []
 "#;
 
 // To think about: PGPASSWORD PGHOST PGUSER PGPORT PGDATABASE maybe tell the model to set that in variables.yaml as well

--- a/src/integrations/integr_postgres.rs
+++ b/src/integrations/integr_postgres.rs
@@ -268,7 +268,7 @@ available:
   when_isolated_possible: true
 confirmation:
   ask_user_default: ["psql*[!SELECT]*"]
-  deny_user_default: []
+  deny_default: []
 "#;
 
 // To think about: PGPASSWORD PGHOST PGUSER PGPORT PGDATABASE maybe tell the model to set that in variables.yaml as well

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -27,7 +27,7 @@ pub mod setting_up_integrations;
 pub mod running_integrations;
 pub mod utils;
 
-use integr_abstract::{IntegrationTrait, IntegrationCommon};
+use integr_abstract::IntegrationTrait;
 
 
 pub fn integration_from_name(n: &str) -> Result<Box<dyn IntegrationTrait + Send + Sync>, String>
@@ -96,22 +96,6 @@ pub const INTEGRATIONS_DEFAULT_YAML: &str = r#"# This file is used to configure 
 #
 # Here you can set up which commands require confirmation or must be denied. If both apply, the command is denied.
 # Rules use glob patterns for wildcard matching (https://en.wikipedia.org/wiki/Glob_(programming))
-#
-
-commands_need_confirmation:
-  - "gh * delete*"
-  - "glab * delete*"
-  - "psql*[!SELECT]*"
-commands_deny:
-  - "docker* rm *"
-  - "docker* remove *"
-  - "docker* rmi *"
-  - "docker* pause *"
-  - "docker* stop *"
-  - "docker* kill *"
-  - "gh auth token*"
-  - "glab auth token*"
-
 
 # Command line: things you can call and immediately get an answer
 #cmdline:

--- a/src/integrations/setting_up_integrations.rs
+++ b/src/integrations/setting_up_integrations.rs
@@ -262,8 +262,8 @@ pub fn read_integrations_d(
                     continue;
                 }
             };
-            rec.ask_user = get_array_of_str_or_empty(&schema, "confirmation/ask_user_default");
-            rec.deny = get_array_of_str_or_empty(&schema, "confirmation/deny_default");
+            rec.ask_user = get_array_of_str_or_empty(&schema, "/confirmation/ask_user_default");
+            rec.deny = get_array_of_str_or_empty(&schema, "/confirmation/deny_default");
         }
     }
 
@@ -414,12 +414,12 @@ pub async fn integration_config_get(
                         confirmation_ask_user = if j.get("confirmation").is_some() { 
                             get_array_of_str_or_empty(&j, "confirmation/ask_user") 
                         } else { 
-                            get_array_of_str_or_empty(&result.integr_schema, "confirmation/ask_user_default") 
+                            get_array_of_str_or_empty(&result.integr_schema, "/confirmation/ask_user_default") 
                         };
                         confirmation_deny = if j.get("confirmation").is_some() {
                             get_array_of_str_or_empty(&j, "confirmation/deny")
                         } else {
-                            get_array_of_str_or_empty(&result.integr_schema, "confirmation/deny_default")
+                            get_array_of_str_or_empty(&result.integr_schema, "/confirmation/deny_default")
                         };
                         let did_it_work = integration_box.integr_settings_apply(&j);
                         if let Err(e) = did_it_work {

--- a/src/integrations/setting_up_integrations.rs
+++ b/src/integrations/setting_up_integrations.rs
@@ -4,11 +4,13 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use regex::Regex;
 use serde::Serialize;
+use serde_json::json;
 use tokio::sync::RwLock as ARwLock;
 use tokio::fs as async_fs;
 use tokio::io::AsyncWriteExt;
 
 use crate::global_context::GlobalContext;
+use crate::integrations::integr_abstract::IntegrationTrait;
 // use crate::tools::tools_description::Tool;
 // use crate::yaml_configs::create_configs::{integrations_enabled_cfg, read_yaml_into_value};
 
@@ -29,6 +31,8 @@ pub struct IntegrationRecord {
     pub icon_path: String,
     pub on_your_laptop: bool,
     pub when_isolated: bool,
+    pub ask_user: Vec<String>,
+    pub deny: Vec<String>,
     #[serde(skip_serializing)]
     pub config_unparsed: serde_json::Value,
 }
@@ -37,6 +41,19 @@ pub struct IntegrationRecord {
 pub struct IntegrationResult {
     pub integrations: Vec<IntegrationRecord>,
     pub error_log: Vec<YamlError>,
+}
+
+fn get_array_of_str_or_empty(val: &serde_json::Value, path: &str) -> Vec<String> {
+    val.pointer(path)
+        .and_then(|val| {
+            val.as_array().map(|array| {
+                array
+                    .iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect::<Vec<String>>()
+            })
+        })
+        .unwrap_or_default()
 }
 
 pub fn read_integrations_d(
@@ -224,6 +241,32 @@ pub fn read_integrations_d(
         }
     }
 
+    // 5. Fill confirmation in each record
+    for rec in &mut result {
+        if !rec.integr_config_exists {
+            continue;
+        }
+        
+        if let Some(confirmation) = rec.config_unparsed.get("confirmation") {
+            rec.ask_user = get_array_of_str_or_empty(&confirmation, "ask_user");
+            rec.deny = get_array_of_str_or_empty(&confirmation, "deny");
+        } else {
+            let schema = match crate::integrations::integration_from_name(rec.integr_name.as_str()) {
+                Ok(i) => {
+                    serde_json::to_value(
+                        serde_yaml::from_str::<serde_yaml::Value>(i.integr_schema()).expect("schema is invalid")
+                    ).expect("schema is invalid")
+                }
+                Err(err) => {
+                    tracing::warn!("failed to retrieve schema from {}: {err}", rec.integr_name);
+                    continue;
+                }
+            };
+            rec.ask_user = get_array_of_str_or_empty(&schema, "confirmation/ask_user_default");
+            rec.deny = get_array_of_str_or_empty(&schema, "confirmation/deny_default");
+        }
+    }
+
     result
 }
 
@@ -357,7 +400,9 @@ pub async fn integration_config_get(
     let mut available = serde_json::json!({
         "on_your_laptop": false,
         "when_isolated": false
-    });
+    });  
+    let mut confirmation_ask_user = vec![];
+    let mut confirmation_deny = vec![];
     if exists {
         match fs::read_to_string(&sanitized_path) {
             Ok(content) => {
@@ -366,6 +411,16 @@ pub async fn integration_config_get(
                         let j = serde_json::to_value(y).unwrap();
                         available["on_your_laptop"] = j.get("available").and_then(|v| v.get("on_your_laptop")).and_then(|v| v.as_bool()).unwrap_or(false).into();
                         available["when_isolated"] = j.get("available").and_then(|v| v.get("when_isolated")).and_then(|v| v.as_bool()).unwrap_or(false).into();
+                        confirmation_ask_user = if j.get("confirmation").is_some() { 
+                            get_array_of_str_or_empty(&j, "confirmation/ask_user") 
+                        } else { 
+                            get_array_of_str_or_empty(&result.integr_schema, "confirmation/ask_user_default") 
+                        };
+                        confirmation_deny = if j.get("confirmation").is_some() {
+                            get_array_of_str_or_empty(&j, "confirmation/deny")
+                        } else {
+                            get_array_of_str_or_empty(&result.integr_schema, "confirmation/deny_default")
+                        };
                         let did_it_work = integration_box.integr_settings_apply(&j);
                         if let Err(e) = did_it_work {
                             tracing::error!("oops: {}", e);
@@ -384,13 +439,17 @@ pub async fn integration_config_get(
 
     result.integr_values = integration_box.integr_settings_as_json();
     result.integr_values["available"] = available;
+    result.integr_values["confirmation"] = serde_json::json!({
+        "ask_user": confirmation_ask_user,
+        "deny": confirmation_deny
+    });
     Ok(result)
 }
 
 pub async fn integration_config_save(
     integr_config_path: &String,
     integr_values: &serde_json::Value,
-) -> Result<(), String> {
+) -> Result<(), String> {    
     let config_path = crate::files_correction::canonical_path(integr_config_path);
     let (integr_name, _project_path) = crate::integrations::setting_up_integrations::split_path_into_project_and_integration(&config_path)
         .map_err(|e| format!("Failed to split path: {}", e))?;
@@ -398,6 +457,11 @@ pub async fn integration_config_save(
         .map_err(|e| format!("Failed to load integrations: {}", e))?;
 
     integration_box.integr_settings_apply(integr_values)?;  // this will produce "no field XXX" errors
+    let schema_json = {
+        let y: serde_yaml::Value = serde_yaml::from_str(integration_box.integr_schema()).unwrap();
+        let j = serde_json::to_value(y).unwrap();
+        j
+    };
 
     let mut sanitized_json: serde_json::Value = integration_box.integr_settings_as_json();
     tracing::info!("posted values:\n{}", serde_json::to_string_pretty(integr_values).unwrap());
@@ -406,6 +470,12 @@ pub async fn integration_config_save(
     }
     sanitized_json["available"]["on_your_laptop"] = integr_values.pointer("/available/on_your_laptop").cloned().unwrap_or(serde_json::Value::Bool(false));
     sanitized_json["available"]["when_isolated"] = integr_values.pointer("/available/when_isolated").cloned().unwrap_or(serde_json::Value::Bool(false));
+    sanitized_json["confirmation"]["ask_user"] = integr_values.pointer("/confirmation/ask_user").cloned().unwrap_or(
+        json!(get_array_of_str_or_empty(&schema_json, "/confirmation/ask_user_default"))
+    );
+    sanitized_json["confirmation"]["deny"] = integr_values.pointer("/confirmation/deny").cloned().unwrap_or(
+        json!(get_array_of_str_or_empty(&schema_json, "/confirmation/deny_default"))
+    );
     tracing::info!("writing to {}:\n{}", config_path.display(), serde_json::to_string_pretty(&sanitized_json).unwrap());
     let sanitized_yaml = serde_yaml::to_value(sanitized_json).unwrap();
 

--- a/src/integrations/setting_up_integrations.rs
+++ b/src/integrations/setting_up_integrations.rs
@@ -243,10 +243,6 @@ pub fn read_integrations_d(
 
     // 5. Fill confirmation in each record
     for rec in &mut result {
-        if !rec.integr_config_exists {
-            continue;
-        }
-        
         if let Some(confirmation) = rec.config_unparsed.get("confirmation") {
             rec.ask_user = get_array_of_str_or_empty(&confirmation, "ask_user");
             rec.deny = get_array_of_str_or_empty(&confirmation, "deny");

--- a/src/tools/tools_description.rs
+++ b/src/tools/tools_description.rs
@@ -11,15 +11,10 @@ use tokio::sync::Mutex as AMutex;
 use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::{ChatUsage, ContextEnum};
 use crate::global_context::GlobalContext;
+use crate::integrations::integr_abstract::IntegrationConfirmation;
 use crate::tools::tools_execute::{command_should_be_confirmed_by_user, command_should_be_denied};
 // use crate::integrations::docker::integr_docker::ToolDocker;
 
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CommandsRequireConfirmationConfig {
-    pub commands_need_confirmation: Vec<String>,
-    pub commands_deny: Vec<String>,
-}
 
 #[derive(Clone, Debug)]
 pub enum MatchConfirmDenyResult {
@@ -48,16 +43,15 @@ pub trait Tool: Send + Sync {
 
     fn match_against_confirm_deny(
         &self,
-        args: &HashMap<String, Value>,
-        confirmation_rules: &Option<CommandsRequireConfirmationConfig>,
+        args: &HashMap<String, Value>
     ) -> Result<MatchConfirmDeny, String> {
         let command_to_match = self.command_to_match_against_confirm_deny(&args).map_err(|e| {
             format!("Error getting tool command to match: {}", e)
         })?;
 
         if !command_to_match.is_empty() {
-            if let Some(rules) = &confirmation_rules {
-                let (is_denied, deny_rule) = command_should_be_denied(&command_to_match, &rules.commands_deny);
+            if let Some(rules) = &self.confirmation_info() {
+                let (is_denied, deny_rule) = command_should_be_denied(&command_to_match, &rules.deny_user_default);
                 if is_denied {
                     return Ok(MatchConfirmDeny {
                         result: MatchConfirmDenyResult::DENY,
@@ -65,7 +59,7 @@ pub trait Tool: Send + Sync {
                         rule: deny_rule.clone(),
                     });
                 }
-                let (needs_confirmation, confirmation_rule) = command_should_be_confirmed_by_user(&command_to_match, &rules.commands_need_confirmation);
+                let (needs_confirmation, confirmation_rule) = command_should_be_confirmed_by_user(&command_to_match, &rules.ask_user_default);
                 if needs_confirmation {
                     return Ok(MatchConfirmDeny {
                         result: MatchConfirmDenyResult::CONFIRMATION,
@@ -87,6 +81,12 @@ pub trait Tool: Send + Sync {
         _args: &HashMap<String, Value>,
     ) -> Result<String, String> {
         Ok("".to_string())
+    }
+
+    fn confirmation_info(
+        &self,
+    ) -> Option<IntegrationConfirmation> {
+        None
     }
 
     fn tool_depends_on(&self) -> Vec<String> { vec![] }   // "ast", "vecdb"
@@ -226,17 +226,6 @@ pub async fn tools_merged_and_filtered(
     }
 
     Ok(filtered_tools)
-}
-
-pub async fn commands_require_confirmation_rules_from_integrations_yaml(gcx: Arc<ARwLock<GlobalContext>>) -> Result<CommandsRequireConfirmationConfig, String>
-{
-    // XXX
-    // let integrations_value = read_integrations_yaml(gcx.clone()).await?;
-    let config_dir = gcx.read().await.config_dir.clone();
-    let integrations_value = read_integrations_yaml(&config_dir).await?;
-
-    serde_yaml::from_value::<CommandsRequireConfirmationConfig>(integrations_value)
-        .map_err(|e| format!("Failed to parse CommandsRequireConfirmationConfig: {}", e))
 }
 
 const BUILT_IN_TOOLS: &str = r####"

--- a/src/tools/tools_description.rs
+++ b/src/tools/tools_description.rs
@@ -51,7 +51,7 @@ pub trait Tool: Send + Sync {
 
         if !command_to_match.is_empty() {
             if let Some(rules) = &self.confirmation_info() {
-                let (is_denied, deny_rule) = command_should_be_denied(&command_to_match, &rules.deny_user_default);
+                let (is_denied, deny_rule) = command_should_be_denied(&command_to_match, &rules.deny);
                 if is_denied {
                     return Ok(MatchConfirmDeny {
                         result: MatchConfirmDenyResult::DENY,
@@ -59,7 +59,7 @@ pub trait Tool: Send + Sync {
                         rule: deny_rule.clone(),
                     });
                 }
-                let (needs_confirmation, confirmation_rule) = command_should_be_confirmed_by_user(&command_to_match, &rules.ask_user_default);
+                let (needs_confirmation, confirmation_rule) = command_should_be_confirmed_by_user(&command_to_match, &rules.ask_user);
                 if needs_confirmation {
                     return Ok(MatchConfirmDeny {
                         result: MatchConfirmDenyResult::CONFIRMATION,


### PR DESCRIPTION
- Remove hardcoded command confirmation and denial rules from `mod.rs`.
- Introduce `confirmation_info()` method to provide custom confirmation and denial configurations for integrations.
- Restructure `IntegrationConfirmation` and `IntegrationAvailable` by renaming their fields for clarity.
- Integrate confirmation and denial rule parsing directly within each integration's configuration.
- Remove redundant function `commands_require_confirmation_rules_from_integrations_yaml`.
- Update tool command matching against confirmation/denial rules to utilize the new method within each integration.
- Refactor confirmation logic and command denial rules