### PR TITLE
Add `tool_description` method to integration modules

### DIFF
--- a/src/integrations/integr_github.rs
+++ b/src/integrations/integr_github.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::{ContextEnum, ChatMessage, ChatContent, ChatUsage};
 
-use crate::tools::tools_description::Tool;
+use crate::tools::tools_description::{Tool, ToolDesc, ToolParam};
 use serde_json::Value;
 use crate::integrations::integr_abstract::{IntegrationCommon, IntegrationConfirmation, IntegrationTrait};
 
@@ -152,6 +152,34 @@ impl Tool for ToolGithub {
 
     fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
         Some(self.integr_common().confirmation)
+    }
+
+    fn tool_description(&self) -> ToolDesc {
+        let supported_commands = vec![
+            "issue create --title <title> --body <body>",
+            "issue list --state open --label <label>",
+            "pr create --title <title> --body <body> --base <branch> --head <branch>",
+            "pr list --state open --label <label>",
+            "repo clone <repository>",
+            "repo create <name> --public",
+            "repo fork <repository>",
+            "repo list",
+            "workflow run <workflow_id>",
+            "workflow list",
+            "..."
+        ];
+        ToolDesc {
+            name: "github".to_string(),
+            agentic: true,
+            experimental: false,
+            description: "Access to GitHub CLI for various GitHub operations such as creating issues, pull requests, and more.".to_string(),
+            parameters: vec![ToolParam {
+                name: "command".to_string(),
+                param_type: "string".to_string(),
+                description: format!("A GitHub CLI command. Example commands:\n{}", supported_commands.join("\n"))
+            }],
+            parameters_required: vec!["command".to_string()],
+        }
     }
 }
 

--- a/src/integrations/integr_gitlab.rs
+++ b/src/integrations/integr_gitlab.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::{ContextEnum, ChatMessage, ChatContent, ChatUsage};
-use crate::tools::tools_description::Tool;
+use crate::tools::tools_description::{Tool, ToolDesc, ToolParam};
 use crate::integrations::integr_abstract::{IntegrationCommon, IntegrationConfirmation, IntegrationTrait};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -150,6 +150,34 @@ impl Tool for ToolGitlab {
 
     fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
         Some(self.integr_common().confirmation)
+    }
+
+    fn tool_description(&self) -> ToolDesc {
+        let supported_commands = vec![
+            "issue create --title <title> --description <description>",
+            "issue list --state opened --label <label>",
+            "mr create --title <title> --description <description> --source-branch <branch> --target-branch <branch>",
+            "mr list --state opened --label <label>",
+            "repo clone <repository>",
+            "repo create <name> --visibility public",
+            "repo fork <repository>",
+            "repo list",
+            "pipeline run <pipeline_id>",
+            "pipeline list",
+            "..."
+        ];
+        ToolDesc {
+            name: "gitlab".to_string(),
+            agentic: true,
+            experimental: false,
+            description: "Access to GitLab CLI for various GitLab operations such as creating issues, merge requests, and more.".to_string(),
+            parameters: vec![ToolParam {
+                name: "command".to_string(),
+                param_type: "string".to_string(),
+                description: format!("A GitLab CLI command. Example commands:\n{}", supported_commands.join("\n"))
+            }],
+            parameters_required: vec!["command".to_string()],
+        }
     }
 }
 

--- a/src/integrations/integr_mysql.rs
+++ b/src/integrations/integr_mysql.rs
@@ -2,7 +2,7 @@ use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::ContextEnum;
 use crate::call_validation::{ChatContent, ChatMessage, ChatUsage};
 use crate::integrations::go_to_configuration_message;
-use crate::tools::tools_description::Tool;
+use crate::tools::tools_description::{Tool, ToolDesc, ToolParam};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -165,6 +165,31 @@ impl Tool for ToolMysql {
 
     fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
         Some(self.integr_common().confirmation)
+    }
+
+    fn tool_description(&self) -> ToolDesc {
+        let supported_commands = vec![
+            "SHOW DATABASES;",
+            "SHOW TABLES;",
+            "SELECT * FROM <table_name>;",
+            "INSERT INTO <table_name> (column1, column2) VALUES (value1, value2);",
+            "UPDATE <table_name> SET column1 = value1 WHERE condition;",
+            "DELETE FROM <table_name> WHERE condition;",
+            "CREATE TABLE <table_name> (column1 datatype, column2 datatype, ...);",
+            "..."
+        ];
+        ToolDesc {
+            name: "mysql".to_string(),
+            agentic: true,
+            experimental: false,
+            description: "Access to MySQL database for various operations such as querying data, inserting, updating, and deleting records.".to_string(),
+            parameters: vec![ToolParam {
+                name: "query".to_string(),
+                param_type: "string".to_string(),
+                description: format!("A MySQL query. Example queries:\n{}", supported_commands.join("\n"))
+            }],
+            parameters_required: vec!["query".to_string()],
+        }
     }
 }
 

--- a/src/integrations/integr_postgres.rs
+++ b/src/integrations/integr_postgres.rs
@@ -2,7 +2,7 @@ use crate::at_commands::at_commands::AtCommandsContext;
 use crate::call_validation::ContextEnum;
 use crate::call_validation::{ChatContent, ChatMessage, ChatUsage};
 use crate::integrations::go_to_configuration_message;
-use crate::tools::tools_description::Tool;
+use crate::tools::tools_description::{Tool, ToolDesc, ToolParam};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -164,6 +164,31 @@ impl Tool for ToolPostgres {
 
     fn confirmation_info(&self) -> Option<IntegrationConfirmation> {
         Some(self.integr_common().confirmation)
+    }
+
+    fn tool_description(&self) -> ToolDesc {
+        let supported_commands = vec![
+            "SELECT * FROM <table_name>;",
+            "INSERT INTO <table_name> (column1, column2) VALUES (value1, value2);",
+            "UPDATE <table_name> SET column1 = value1 WHERE condition;",
+            "DELETE FROM <table_name> WHERE condition;",
+            "CREATE TABLE <table_name> (column1 datatype, column2 datatype, ...);",
+            "ALTER TABLE <table_name> ADD COLUMN <column_name> <datatype>;",
+            "ALTER TABLE <table_name> DROP COLUMN <column_name>;",
+            "..."
+        ];
+        ToolDesc {
+            name: "postgres".to_string(),
+            agentic: true,
+            experimental: false,
+            description: "Access to PostgreSQL database for various operations such as querying data, inserting, updating, and deleting records.".to_string(),
+            parameters: vec![ToolParam {
+                name: "query".to_string(),
+                param_type: "string".to_string(),
+                description: format!("A PostgreSQL query. Example queries:\n{}", supported_commands.join("\n"))
+            }],
+            parameters_required: vec!["query".to_string()],
+        }
     }
 }
 


### PR DESCRIPTION
Enhance the MySQL, PostgreSQL, GitHub, GitLab, and Docker integration modules by adding a `tool_description` method. This method provides metadata about the tool including name, description, parameters, and example commands, improving usability and documentation across integrations.