### PR TITLE
fix: fallback to git cli just in case ls files with library fails

### DIFF
--- a/src/files_in_workspace.rs
+++ b/src/files_in_workspace.rs
@@ -213,7 +213,13 @@ async fn _run_command(cmd: &str, args: &[&str], path: &PathBuf, filter_out_statu
 
 async fn ls_files_under_version_control(path: &PathBuf) -> Option<Vec<PathBuf>> {
     if path.join(".git").exists() {
-        git_ls_files(path)
+        if let Some(files) = git_ls_files(path) {
+            return Some(files);
+        }
+        if which("git").is_ok() {
+            return _run_command("git", &["ls-files", "--cached", "--modified", "--others", "--exclude-standard"], path, false).await;
+        }
+        None
     } else if path.join(".hg").exists() && which("hg").is_ok() {
         // Mercurial repository
         _run_command("hg", &["status", "--added", "--modified", "--clean", "--unknown", "--no-status"], path, false).await

--- a/src/git.rs
+++ b/src/git.rs
@@ -67,7 +67,7 @@ pub fn git_ls_files(repository_path: &PathBuf) -> Option<Vec<PathBuf>> {
             files.push(repository_path.join(path));
         }
     }
-    if !files.is_empty() { Some(files) } else { None }
+    Some(files)
 }
 
 /// Similar to git checkout -b <branch_name>


### PR DESCRIPTION
Do we need it? probably no, maybe because of windows permission issues but will it work with this one? if library fails due to permissions maybe cli too? Could be tested.