### PR TITLE
Cat Fix: skeletonize: true and file is not supported by AST: was ignored

### DIFF
--- a/src/postprocessing/pp_context_files.rs
+++ b/src/postprocessing/pp_context_files.rs
@@ -36,7 +36,7 @@ pub struct FileLine {
     pub useful: f32,
     pub color: String,
     pub take: bool,
-    pub ignore_take_floor: bool,
+    pub take_ignoring_floor: bool,  // if no ast for this file, then ignore the take_floor
 }
 
 
@@ -54,7 +54,7 @@ fn collect_lines_from_files(
                 useful: 0.0,
                 color: "".to_string(),
                 take: false,
-                ignore_take_floor: false,
+                take_ignoring_floor: false,
             };
             let lines_in_files_mut = lines_in_files.entry(file_ref.cpath.clone()).or_insert(vec![]);
             lines_in_files_mut.push(a);
@@ -87,9 +87,10 @@ fn collect_lines_from_files(
     }
 
     for (file_name, lines) in lines_in_files.iter_mut() {
-        if lines.iter().all(|x| x.useful < settings.take_floor) {
-            info!("pp: FN {file_name} ignoring skeletonize=true: take_floor > all_lines.useful");
-            lines.iter_mut().for_each(|x| x.ignore_take_floor = true);
+        let file = lines.first().unwrap().file_ref.clone();
+        if file.symbols_sorted_by_path_len.is_empty() {
+            info!("{file_name} ignoring skeletonize because no symbols found in the file, maybe the file format is not supported or the file is empty");
+            lines.iter_mut().for_each(|x| x.take_ignoring_floor = true);
         }
     }
 
@@ -255,7 +256,7 @@ async fn pp_limit_and_merge(
     let mut files_mentioned_set = HashSet::new();
     let mut files_mentioned_sequence = vec![];
     for line_ref in lines_by_useful.iter_mut() {
-        if !line_ref.ignore_take_floor && line_ref.useful <= settings.take_floor {
+        if !line_ref.take_ignoring_floor && line_ref.useful <= settings.take_floor {
             continue;
         }
         let mut ntokens = count_tokens(&tokenizer.read().unwrap(), &line_ref.line_content);

--- a/src/tools/tool_ast_definition.rs
+++ b/src/tools/tool_ast_definition.rs
@@ -9,7 +9,7 @@ use crate::ast::ast_structs::AstDB;
 use crate::ast::ast_db::fetch_counters;
 use crate::tools::tools_description::Tool;
 use crate::call_validation::{ChatMessage, ChatContent, ContextEnum, ContextFile};
-
+use crate::tools::tool_cat::parse_skeleton_from_args;
 
 pub struct ToolAstDefinition;
 
@@ -32,20 +32,7 @@ impl Tool for ToolAstDefinition {
 
         symbol = symbol.replace('.', "::");
 
-        let skeleton = match args.get("skeleton") {
-            Some(Value::Bool(s)) => *s,
-            Some(Value::String(s)) => {
-                if s == "true" {
-                    true
-                } else if s == "false" {
-                    false
-                } else {
-                    return Err(format!("argument `skeleton` is not a bool: {:?}", s));
-                }
-            }
-            Some(v) => return Err(format!("argument `skeleton` is not a bool: {:?}", v)),
-            None => false,
-        };
+        let skeleton = parse_skeleton_from_args(args)?;
         ccx.lock().await.pp_skeleton = skeleton;
 
         let gcx = ccx.lock().await.global_context.clone();

--- a/src/tools/tool_ast_reference.rs
+++ b/src/tools/tool_ast_reference.rs
@@ -9,7 +9,7 @@ use crate::at_commands::at_commands::AtCommandsContext;
 use crate::tools::tools_description::Tool;
 use crate::call_validation::{ChatMessage, ChatContent, ContextEnum, ContextFile};
 use crate::tools::tool_ast_definition::there_are_definitions_with_similar_names_though;
-
+use crate::tools::tool_cat::parse_skeleton_from_args;
 
 pub struct ToolAstReference;
 
@@ -32,20 +32,7 @@ impl Tool for ToolAstReference {
 
         symbol = symbol.replace('.', "::");
 
-        let skeleton = match args.get("skeleton") {
-            Some(Value::Bool(s)) => *s,
-            Some(Value::String(s)) => {
-                if s == "true" {
-                    true
-                } else if s == "false" {
-                    false
-                } else {
-                    return Err(format!("argument `skeleton` is not a bool: {:?}", s));
-                }
-            }
-            Some(v) => return Err(format!("argument `skeleton` is not a bool: {:?}", v)),
-            None => false,
-        };
+        let skeleton = parse_skeleton_from_args(args)?;
         ccx.lock().await.pp_skeleton = skeleton;
 
         let gcx = ccx.lock().await.global_context.clone();

--- a/src/tools/tool_cat.rs
+++ b/src/tools/tool_cat.rs
@@ -23,6 +23,22 @@ pub struct ToolCat;
 
 const CAT_MAX_IMAGES_CNT: usize = 1;
 
+pub fn parse_skeleton_from_args(args: &HashMap<String, Value>) -> Result<bool, String> {
+    Ok(match args.get("skeleton") {
+        Some(Value::Bool(s)) => *s,
+        Some(Value::String(s)) => {
+            if s == "true" {
+                true
+            } else if s == "false" {
+                false
+            } else {
+                return Err(format!("argument `skeleton` is not a bool: {:?}", s));
+            }
+        }
+        Some(v) => return Err(format!("argument `skeleton` is not a bool: {:?}", v)),
+        None => false
+    })
+}
 
 #[async_trait]
 impl Tool for ToolCat {
@@ -57,20 +73,7 @@ impl Tool for ToolCat {
             Some(v) => return Err(format!("argument `symbols` is not a string: {:?}", v)),
             None => vec![],
         };
-        let skeleton = match args.get("skeleton") {
-            Some(Value::Bool(s)) => *s,
-            Some(Value::String(s)) => {
-                if s == "true" {
-                    true
-                } else if s == "false" {
-                    false
-                } else {
-                    return Err(format!("argument `skeleton` is not a bool: {:?}", s));
-                }
-            }
-            Some(v) => return Err(format!("argument `skeleton` is not a bool: {:?}", v)),
-            None => false,  // the default
-        };
+        let skeleton = parse_skeleton_from_args(args)?;
         ccx.lock().await.pp_skeleton = skeleton;
 
         let (filenames_present, symbols_not_found, not_found_messages, context_enums, multimodal) = paths_and_symbols_to_cat(ccx.clone(), paths, symbols).await;


### PR DESCRIPTION
<img width="812" alt="image" src="https://github.com/user-attachments/assets/5d1717fb-8769-44c8-abca-1c36090beb2e" />
<img width="636" alt="image" src="https://github.com/user-attachments/assets/6fdd656a-9a31-470c-aa2f-051bb1fd91dc" />

from logs:
```
102424.930 INFO src/postprocessing/pp_context_files.rs:92 pp: FN /Users/valerii/code/refact-lsp/helloworld.tsx ignoring skeletonize=true: take_floor > all_lines.useful
```