### PR TITLE
Patch adjust confirmation

### DIFF
--- a/src/http/routers/v1/at_tools.rs
+++ b/src/http/routers/v1/at_tools.rs
@@ -21,6 +21,8 @@ use crate::tools::tools_execute::run_tools;
 #[derive(Serialize, Deserialize, Clone)]
 struct ToolsPermissionCheckPost {
     pub tool_calls: Vec<ChatToolCall>,
+    #[serde(default)]
+    pub messages: Vec<ChatMessage>,
 }
 
 #[derive(Serialize)]
@@ -101,7 +103,7 @@ pub async fn handle_v1_tools_check_if_confirmation_needed(
         .map_err(|e| ScratchError::new(StatusCode::UNPROCESSABLE_ENTITY, format!("JSON problem: {}", e)))?;
 
     let ccx = Arc::new(AMutex::new(AtCommandsContext::new(
-        gcx.clone(), 1000, 1, false, vec![], "".to_string(), false
+        gcx.clone(), 1000, 1, false, post.messages.clone(), "".to_string(), false
     ).await)); // used only for should_confirm
 
     let all_tools = match tools_merged_and_filtered(gcx.clone(), true).await {

--- a/src/integrations/integr_shell.rs
+++ b/src/integrations/integr_shell.rs
@@ -145,8 +145,9 @@ impl Tool for ToolShell {
         }
     }
 
-    fn match_against_confirm_deny(
+    async fn match_against_confirm_deny(
         &self,
+        _ccx: Arc<AMutex<AtCommandsContext>>,
         args: &HashMap<String, Value>
     ) -> Result<MatchConfirmDeny, String> {
         let command_to_match = self.command_to_match_against_confirm_deny(&args).map_err(|e| {

--- a/src/tools/tools_description.rs
+++ b/src/tools/tools_description.rs
@@ -40,8 +40,9 @@ pub trait Tool: Send + Sync {
         args: &HashMap<String, Value>
     ) -> Result<(bool, Vec<ContextEnum>), String>;
 
-    fn match_against_confirm_deny(
+    async fn match_against_confirm_deny(
         &self,
+        _ccx: Arc<AMutex<AtCommandsContext>>,
         args: &HashMap<String, Value>
     ) -> Result<MatchConfirmDeny, String> {
         let command_to_match = self.command_to_match_against_confirm_deny(&args).map_err(|e| {

--- a/src/tools/tools_execute.rs
+++ b/src/tools/tools_execute.rs
@@ -190,7 +190,7 @@ pub async fn run_tools(
 
         {
             let cmd_lock = cmd.lock().await;
-            match cmd_lock.match_against_confirm_deny(&args) {
+            match cmd_lock.match_against_confirm_deny(ccx.clone(), &args).await {
                 Ok(res) => {
                     match res.result {
                         MatchConfirmDenyResult::DENY => {


### PR DESCRIPTION
https://refact.fibery.io/Software_Development/Current-Week-by-dev-362#Task/patch()-confirmation-only-for-valid-arguments,-and-also-add-to-the-command-file-names-to-be-changed-651

AFTER (as expected):
![image](https://github.com/user-attachments/assets/d2919e3d-4420-4870-8e54-843c5f97ae8f)

BEFORE (wrong):
![image](https://github.com/user-attachments/assets/c4510e18-9c26-4b15-a16b-206d796a8917)
