### PR TITLE
Load caps return status code sometimes different than 500

### DIFF
--- a/src/custom_error.rs
+++ b/src/custom_error.rs
@@ -49,6 +49,14 @@ impl ScratchError {
         }
     }
 
+    pub fn new_internal(message: String) -> Self {
+        ScratchError {
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+            telemetry_skip: false,
+        }
+    }
+
     pub fn to_response(&self) -> Response<Body> {
         let body = json!({"detail": self.message}).to_string();
         error!("client will see {}", body);

--- a/src/custom_error.rs
+++ b/src/custom_error.rs
@@ -49,6 +49,8 @@ impl ScratchError {
         }
     }
 
+    /// This is a helper function to create a new [`ScratchError`]
+    /// with `status_code` = `INTERNAL_SERVER_ERROR`
     pub fn new_internal(message: String) -> Self {
         ScratchError {
             status_code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/global_context.rs
+++ b/src/global_context.rs
@@ -250,7 +250,10 @@ pub async fn try_load_caps_quickly_if_not_present(
                 Err(e) => {
                     error!("caps fetch failed: {:?}", e);
                     gcx_locked.caps_last_error = format!("caps fetch failed: {}", e);
-                    return Err(ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, gcx_locked.caps_last_error.clone()));
+                    Err(ScratchError::new(
+                        e.status_code,
+                        gcx_locked.caps_last_error.clone(),
+                    ))
                 }
             }
         }


### PR DESCRIPTION
This pull request includes several changes to improve error handling and streamline code in the `src/caps.rs` file. The most important changes involve refactoring error handling to use a custom `ScratchError` type and updating function signatures accordingly.

Improvements to error handling:

* [`src/caps.rs`](diffhunk://#diff-348e3defbff7776ca90fa35b75740f6c7840d8c1110de0682dfe4f6eb0865ef1L311-R326): Changed the return type of `load_caps_buf_from_url` and `load_caps` functions to use `ScratchError` instead of `String` for error handling. [[1]](diffhunk://#diff-348e3defbff7776ca90fa35b75740f6c7840d8c1110de0682dfe4f6eb0865ef1L311-R326) [[2]](diffhunk://#diff-348e3defbff7776ca90fa35b75740f6c7840d8c1110de0682dfe4f6eb0865ef1L372-R425)

Codebase simplification:

* [`src/custom_error.rs`](diffhunk://#diff-5fe165c3bc5082f77db4ab238c3511bcf281c995ac021a7a35528fe74b9a8642R52-R61): Added a new helper function `ScratchError::new_internal` to create `ScratchError` instances with a default `INTERNAL_SERVER_ERROR` status code.
* [`src/global_context.rs`](diffhunk://#diff-81a6d0eaa72beb04d44d74cf99168bef8d889de2d0a87b8d2a4a40efc5b065a9L253-R256): Updated error handling in `try_load_caps_quickly_if_not_present` to use the `status_code` from the original error when creating a new `ScratchError`.

Dependency updates:

* [`src/caps.rs`](diffhunk://#diff-348e3defbff7776ca90fa35b75740f6c7840d8c1110de0682dfe4f6eb0865ef1L1-R13): Reorganized imports to improve readability and maintain consistency.