### PR TITLE
blocklist mechanism

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+use std::path::PathBuf;
+use serde::Deserialize;
+use tokio::sync::RwLock as ARwLock;
+use tokio::time::Duration;
+use tokio::fs;
+use tracing::error;
+use tracing::info;
+use std::time::SystemTime;
+use std::collections::HashMap;
+use walkdir::WalkDir;
+use crate::files_correction::get_project_dirs;
+use crate::global_context::GlobalContext;
+
+
+pub const DEFAULT_BLOCKLIST_DIRS: &[&str] = &[
+    "target", "node_modules", "vendor", "build", "dist",
+    "bin", "pkg", "lib", "lib64", "obj",
+    "out", "venv", "env", "tmp", "temp", "logs",
+    "coverage", "backup", "__pycache__",
+    "_trajectories", ".gradle",
+];
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IndexingSettings {
+    pub blocklist: Vec<String>,
+    pub additional_indexing_dirs: Vec<String>,  // TODO: this field requires different mechanism
+}
+
+impl Default for IndexingSettings {
+    fn default() -> Self {
+        IndexingSettings {
+            blocklist: DEFAULT_BLOCKLIST_DIRS.iter().map(|s| s.to_string()).collect(),
+            additional_indexing_dirs: vec![],
+        }
+    }
+}
+
+impl IndexingSettings {
+    pub fn extend(&self, other: IndexingSettings) -> IndexingSettings {
+        IndexingSettings {
+            blocklist: self.blocklist.iter().chain(other.blocklist.iter()).cloned().collect(),
+            additional_indexing_dirs: self.additional_indexing_dirs.iter().chain(other.additional_indexing_dirs.iter()).cloned().collect(),
+        }
+    }
+}
+
+pub struct WorkspaceIndexingSettings {
+    pub indexing_settings_map: HashMap<String, IndexingSettings>,
+    pub loaded_ts: u64,
+}
+
+impl Default for WorkspaceIndexingSettings {
+    fn default() -> Self {
+        WorkspaceIndexingSettings {
+            indexing_settings_map: HashMap::new(),
+            loaded_ts: 0,
+        }
+    }
+}
+
+impl WorkspaceIndexingSettings {
+    // NOTE: path argument should be absolute
+    pub fn get_indexing_settings(&self, path: PathBuf) -> IndexingSettings {
+        let mut best_workspace: Option<PathBuf> = None;
+
+        for (workspace, _) in &self.indexing_settings_map {
+            let workspace_path = PathBuf::from(workspace);
+            if path.starts_with(&workspace_path) {
+                if best_workspace.is_none() || workspace_path.components().count() > best_workspace.clone().unwrap().components().count() {
+                    best_workspace = Some(workspace_path);
+                }
+            }
+        }
+
+        if let Some(workspace) = best_workspace {
+            self.indexing_settings_map.get(&workspace.to_str().unwrap().to_string()).cloned().unwrap_or_default()
+        } else {
+            IndexingSettings::default()
+        }
+    }
+}
+
+async fn load_project_indexing_settings(gcx: Arc<ARwLock<GlobalContext>>) -> WorkspaceIndexingSettings {
+    let project_dirs = get_project_dirs(gcx.clone()).await;
+
+    let mut refact_paths_project = vec![];
+    for project_dir in project_dirs {
+        let refact_paths: Vec<PathBuf> = WalkDir::new(project_dir)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_dir() && entry.file_name() == ".refact")
+            .map(|entry| entry.path().to_path_buf())
+            .collect();
+        refact_paths_project.extend(refact_paths);
+    }
+
+    let mut indexing_settings_map: HashMap<String, IndexingSettings> = HashMap::new();
+    for refact_path in refact_paths_project {
+        if let Some(project_path) = refact_path.parent() {
+            let indexing_path = refact_path.join("indexing.yaml");
+            match fs::read_to_string(&indexing_path.as_path()).await {
+                Ok(content) => {
+                    match serde_yaml::from_str(&content) {
+                        Ok(indexing_settings) => {
+                            indexing_settings_map.insert(
+                                project_path.to_str().unwrap().to_string(),
+                                IndexingSettings::default().extend(indexing_settings),
+                            );
+                        }
+                        Err(e) => {
+                            error!("parsing {} failed\n{}", indexing_path.display(), e);
+                        }
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    info!("loaded indexing settings: {:?}", indexing_settings_map);
+
+    let loaded_ts = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+    WorkspaceIndexingSettings{
+        indexing_settings_map,
+        loaded_ts,
+    }
+}
+
+const INDEXING_TOO_OLD: Duration = Duration::from_secs(3);
+
+pub async fn load_indexing_settings_if_needed(gcx: Arc<ARwLock<GlobalContext>>) -> Arc<WorkspaceIndexingSettings>
+{
+    {
+        let gcx_locked = gcx.read().await;
+        let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+        if gcx_locked.indexing_settings.loaded_ts + INDEXING_TOO_OLD.as_secs() > current_time {
+            return gcx_locked.indexing_settings.clone();
+        }
+    }
+
+    let indexing_settings = load_project_indexing_settings(gcx.clone()).await;
+    {
+        let mut gcx_locked = gcx.write().await;
+        gcx_locked.indexing_settings = Arc::new(indexing_settings);
+        gcx_locked.indexing_settings.clone()
+    }
+}
+
+// fn is_path_in_additional_indexing_dirs(indexing_settings: &IndexingSettings, path: &str) -> bool {
+//     for dir in indexing_settings.additional_indexing_dirs.iter() {
+//         if !dir.is_empty() && path.contains(dir.as_str()) {
+//             return true;
+//         }
+//     }
+//     false
+// }
+
+pub fn is_this_inside_blacklisted_dir(indexing_settings: &IndexingSettings, path: &PathBuf) -> bool {
+    // if is_path_in_additional_indexing_dirs(indexing_settings, path.to_str().unwrap()) {
+    //     return false;
+    // }
+    let mut path = path.clone();
+    while path.parent().is_some() {
+        path = path.parent().unwrap().to_path_buf();
+        if is_path_blacklisted(&indexing_settings, &path) {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn is_path_blacklisted(indexing_settings: &IndexingSettings, path: &PathBuf) -> bool {
+    // if is_path_in_additional_indexing_dirs(indexing_settings, path.to_str().unwrap()) {
+    //     return false;
+    // }
+    if let Some(file_name) = path.file_name() {
+        if indexing_settings.blocklist.contains(&file_name.to_str().unwrap_or_default().to_string()) {
+            return true;
+        }
+        if let Some(file_name_str) = file_name.to_str() {
+            if file_name_str.starts_with(".") {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/src/file_filter.rs
+++ b/src/file_filter.rs
@@ -16,14 +16,6 @@ pub const SOURCE_FILE_EXTENSIONS: &[&str] = &[
     "cmake", "gradle", "liquid"
 ];
 
-pub(crate) const BLACKLISTED_DIRS: &[&str] = &[
-    "target", "node_modules", "vendor", "build", "dist",
-    "bin", "pkg", "lib", "lib64", "obj",
-    "out", "venv", "env", "tmp", "temp", "logs",
-    "coverage", "backup", "__pycache__",
-    "_trajectories", ".gradle"
-];
-
 pub fn is_valid_file(path: &PathBuf, allow_hidden_folders: bool, ignore_size_thresholds: bool) -> Result<(), Box<dyn std::error::Error>> {
     if !path.is_file() {
         return Err("Path is not a file".into());
@@ -57,22 +49,3 @@ pub fn is_valid_file(path: &PathBuf, allow_hidden_folders: bool, ignore_size_thr
     }
     Ok(())
 }
-
-pub fn is_this_inside_blacklisted_dir(path: &PathBuf) -> bool {
-    let mut path = path.clone();
-    while path.parent().is_some() {
-        path = path.parent().unwrap().to_path_buf();
-        if let Some(file_name) = path.file_name() {
-            if BLACKLISTED_DIRS.contains(&file_name.to_str().unwrap_or_default()) {
-                return true;
-            }
-            if let Some(file_name_str) = file_name.to_str() {
-                if file_name_str.starts_with(".") {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-

--- a/src/files_in_workspace.rs
+++ b/src/files_in_workspace.rs
@@ -16,9 +16,10 @@ use tracing::info;
 use crate::git::git_ls_files;
 use crate::global_context::GlobalContext;
 use crate::telemetry;
-use crate::file_filter::{is_this_inside_blacklisted_dir, is_valid_file, BLACKLISTED_DIRS, SOURCE_FILE_EXTENSIONS};
+use crate::file_filter::{is_valid_file, SOURCE_FILE_EXTENSIONS};
 use crate::ast::ast_indexer_thread::ast_indexer_enqueue_files;
 use crate::privacy::{check_file_privacy, load_privacy_if_needed, PrivacySettings, FilePrivacyLevel};
+use crate::blocklist::{is_this_inside_blacklisted_dir, is_path_blacklisted, load_indexing_settings_if_needed, IndexingSettings, WorkspaceIndexingSettings};
 
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
@@ -241,7 +242,11 @@ async fn ls_files_under_version_control(path: &PathBuf) -> Option<Vec<PathBuf>> 
     }
 }
 
-pub fn ls_files(path: &PathBuf, recursive: bool) -> Result<Vec<PathBuf>, String> {
+pub fn ls_files(
+    indexing_settings: &IndexingSettings,
+    path: &PathBuf,
+    recursive: bool,
+) -> Result<Vec<PathBuf>, String> {
     if !path.is_dir() {
         return Err(format!("path '{}' is not a directory", path.display()));
     }
@@ -265,10 +270,7 @@ pub fn ls_files(path: &PathBuf, recursive: bool) -> Result<Vec<PathBuf>, String>
         entries.sort_by_key(|entry| entry.file_name());
         for entry in entries {
             let path = entry.path();
-            if recursive && path.is_dir() && !(
-                path.file_name().unwrap_or_default().to_str().unwrap_or_default().starts_with(".") ||
-                BLACKLISTED_DIRS.contains(&path.file_name().unwrap_or_default().to_str().unwrap_or_default())
-            ) {
+            if recursive && path.is_dir() && !is_path_blacklisted(&indexing_settings, &path) {
                 dirs_to_visit.push(path);
             } else if path.is_file() {
                 paths.push(path);
@@ -331,6 +333,7 @@ pub async fn detect_vcs_for_a_file_path(file_path: &PathBuf) -> Option<(PathBuf,
 async fn _ls_files_under_version_control_recursive(
     all_files: &mut Vec<PathBuf>,
     vcs_folders: &mut Vec<PathBuf>,
+    workspace_indexing_settings: Arc<WorkspaceIndexingSettings>,
     path: PathBuf,
     allow_files_in_hidden_folders: bool,
     ignore_size_thresholds: bool
@@ -354,7 +357,8 @@ async fn _ls_files_under_version_control_recursive(
             }
         }
         if local_path.is_dir() {
-            if BLACKLISTED_DIRS.contains(&local_path.file_name().unwrap().to_str().unwrap()) {
+            let indexing_settings = workspace_indexing_settings.get_indexing_settings(path.clone());
+            if is_path_blacklisted(&indexing_settings, &local_path) {
                 blacklisted_dirs_cnt += 1;
                 continue;
             }
@@ -396,6 +400,7 @@ async fn _ls_files_under_version_control_recursive(
 
 pub async fn retrieve_files_in_workspace_folders(
     proj_folders: Vec<PathBuf>,
+    workspace_indexing_settings: Arc<WorkspaceIndexingSettings>,
     allow_files_in_hidden_folders: bool,   // true when syncing to remote container
     ignore_size_thresholds: bool,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
@@ -405,6 +410,7 @@ pub async fn retrieve_files_in_workspace_folders(
         _ls_files_under_version_control_recursive(
             &mut all_files,
             &mut vcs_folders,
+            workspace_indexing_settings.clone(),
             proj_folder.clone(),
             allow_files_in_hidden_folders,
             ignore_size_thresholds
@@ -477,8 +483,10 @@ pub async fn enqueue_all_files_from_workspace_folders(
     let folders: Vec<PathBuf> = gcx.read().await.documents_state.workspace_folders.lock().unwrap().clone();
 
     info!("enqueue_all_files_from_workspace_folders started files search with {} folders", folders.len());
+    let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
     let (all_files, vcs_folders) = retrieve_files_in_workspace_folders(
         folders,
+        workspace_indexing_settings,
         false,
         false
     ).await;
@@ -665,8 +673,13 @@ pub async fn file_watcher_event(event: Event, gcx_weak: Weak<ARwLock<GlobalConte
 {
     async fn on_create_modify(gcx_weak: Weak<ARwLock<GlobalContext>>, event: Event) {
         let mut docs = vec![];
+        let mut workspace_indexing_settings = Arc::new(WorkspaceIndexingSettings::default());
+        if let Some(gcx) = gcx_weak.clone().upgrade() {
+            workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
+        }
         for p in &event.paths {
-            if is_this_inside_blacklisted_dir(&p) {  // important to filter BEFORE canonical_path
+            let indexing_settings = workspace_indexing_settings.get_indexing_settings(p.clone());
+            if is_this_inside_blacklisted_dir(&indexing_settings, &p) {  // important to filter BEFORE canonical_path
                 continue;
             }
 
@@ -695,13 +708,19 @@ pub async fn file_watcher_event(event: Event, gcx_weak: Weak<ARwLock<GlobalConte
 
     async fn on_remove(gcx_weak: Weak<ARwLock<GlobalContext>>, event: Event) {
         let mut never_mind = true;
+        let mut workspace_indexing_settings = Arc::new(WorkspaceIndexingSettings::default());
+        if let Some(gcx) = gcx_weak.clone().upgrade() {
+            workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
+        }
         for p in &event.paths {
-            never_mind &= is_this_inside_blacklisted_dir(&p);
+            let indexing_settings = workspace_indexing_settings.get_indexing_settings(p.clone());
+            never_mind &= is_this_inside_blacklisted_dir(&indexing_settings, &p);
         }
         let mut docs = vec![];
         if !never_mind {
             for p in &event.paths {
-                if is_this_inside_blacklisted_dir(&p) {
+                let indexing_settings = workspace_indexing_settings.get_indexing_settings(p.clone());
+                if is_this_inside_blacklisted_dir(&indexing_settings, &p) {
                     continue;
                 }
                 let cpath = crate::files_correction::canonical_path(&p.to_string_lossy().to_string());

--- a/src/fuzzy_search.rs
+++ b/src/fuzzy_search.rs
@@ -76,14 +76,18 @@ where I: IntoIterator<Item = String> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use crate::blocklist::WorkspaceIndexingSettings;
     use crate::files_in_workspace::retrieve_files_in_workspace_folders;
 
     async fn get_candidates_from_workspace_files() -> Vec<String> {
         let proj_folders = vec![PathBuf::from(".").canonicalize().unwrap()];
         let proj_folder = &proj_folders[0];
 
+        let workspace_indexing_settings = Arc::new(WorkspaceIndexingSettings::default());
         let (workspace_files, _vcs_folders) = retrieve_files_in_workspace_folders(
             proj_folders.clone(),
+            workspace_indexing_settings.clone(),
             false,
             false
         ).await;

--- a/src/global_context.rs
+++ b/src/global_context.rs
@@ -23,6 +23,7 @@ use crate::files_in_workspace::DocumentsState;
 use crate::integrations::docker::docker_ssh_tunnel_utils::SshTunnel;
 use crate::integrations::sessions::IntegrationSession;
 use crate::privacy::PrivacySettings;
+use crate::blocklist::WorkspaceIndexingSettings;
 use crate::telemetry::telemetry_structs;
 
 
@@ -162,6 +163,7 @@ pub struct GlobalContext {
     pub documents_state: DocumentsState,
     pub at_commands_preview_cache: Arc<AMutex<AtCommandsPreviewCache>>,
     pub privacy_settings: Arc<PrivacySettings>,
+    pub indexing_settings: Arc<WorkspaceIndexingSettings>,
     pub integration_sessions: HashMap<String, Arc<AMutex<Box<dyn IntegrationSession>>>>,
     pub codelens_cache: Arc<AMutex<crate::http::routers::v1::code_lens::CodeLensCache>>,
     pub docker_ssh_tunnel: Arc<AMutex<Option<SshTunnel>>>,
@@ -371,6 +373,7 @@ pub async fn create_global_context(
         documents_state: DocumentsState::new(workspace_dirs).await,
         at_commands_preview_cache: Arc::new(AMutex::new(AtCommandsPreviewCache::new())),
         privacy_settings: Arc::new(PrivacySettings::default()),
+        indexing_settings: Arc::new(WorkspaceIndexingSettings::default()),
         integration_sessions: HashMap::new(),
         codelens_cache: Arc::new(AMutex::new(crate::http::routers::v1::code_lens::CodeLensCache::default())),
         docker_ssh_tunnel: Arc::new(AMutex::new(None)),

--- a/src/integrations/docker/docker_container_manager.rs
+++ b/src/integrations/docker/docker_container_manager.rs
@@ -8,7 +8,7 @@ use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 use tracing::{error, info, warn};
 use url::Url;
 use walkdir::WalkDir;
-
+use crate::blocklist::load_indexing_settings_if_needed;
 use crate::files_correction::get_project_dirs;
 use crate::global_context::GlobalContext;
 use crate::http::http_post;
@@ -354,8 +354,10 @@ async fn docker_container_sync_workspace(
     tar_builder.follow_symlinks(true);
     tar_builder.mode(async_tar::HeaderMode::Complete);
 
+    let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
     let (all_files, _vcs_folders) = crate::files_in_workspace::retrieve_files_in_workspace_folders(
         vec![workspace_folder.clone()],
+        workspace_indexing_settings,
         false,
         false,
     ).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ mod git;
 mod agentic;
 mod trajectories;
 
+mod blocklist;
+
 #[tokio::main]
 async fn main() {
     let cpu_num = std::thread::available_parallelism().unwrap().get();

--- a/src/tools/tool_cat.rs
+++ b/src/tools/tool_cat.rs
@@ -214,8 +214,7 @@ pub async fn paths_and_symbols_to_cat(
             };
             let path = PathBuf::from(candidate);
             let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
-            let indexing_settings = workspace_indexing_settings.get_indexing_settings(path.clone());
-            let files_in_dir = ls_files(&indexing_settings, &path, false).unwrap_or(vec![]);
+            let files_in_dir = ls_files(&workspace_indexing_settings, &path, false).unwrap_or(vec![]);
             corrected_paths.extend(files_in_dir.into_iter().map(|x|x.to_string_lossy().to_string()));
         }
     }

--- a/src/tools/tool_cat.rs
+++ b/src/tools/tool_cat.rs
@@ -17,6 +17,7 @@ use crate::scratchpads::multimodality::MultimodalElement;
 use std::io::Cursor;
 use image::imageops::FilterType;
 use image::{ImageFormat, ImageReader};
+use crate::blocklist::load_indexing_settings_if_needed;
 
 pub struct ToolCat;
 
@@ -211,7 +212,10 @@ pub async fn paths_and_symbols_to_cat(
                 Ok(f) => f,
                 Err(e) => { not_found_messages.push(e); continue;}
             };
-            let files_in_dir = ls_files(&PathBuf::from(candidate), false).unwrap_or(vec![]);
+            let path = PathBuf::from(candidate);
+            let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
+            let indexing_settings = workspace_indexing_settings.get_indexing_settings(path.clone());
+            let files_in_dir = ls_files(&indexing_settings, &path, false).unwrap_or(vec![]);
             corrected_paths.extend(files_in_dir.into_iter().map(|x|x.to_string_lossy().to_string()));
         }
     }

--- a/src/tools/tool_tree.rs
+++ b/src/tools/tool_tree.rs
@@ -12,6 +12,7 @@ use crate::tools::tools_description::Tool;
 use crate::call_validation::{ChatMessage, ChatContent, ContextEnum};
 use crate::files_correction::{correct_to_nearest_dir_path, correct_to_nearest_filename, get_project_dirs, paths_from_anywhere};
 use crate::files_in_workspace::ls_files;
+use crate::blocklist::load_indexing_settings_if_needed;
 
 
 pub struct ToolTree;
@@ -64,7 +65,9 @@ impl Tool for ToolTree {
                     return Err(format!("Cannot execute tree(), '{path}' is not within the project directories."));
                 }
 
-                let paths_in_dir = ls_files(&true_path, true).unwrap_or(vec![]);
+                let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
+                let indexing_settings = workspace_indexing_settings.get_indexing_settings(true_path.clone());
+                let paths_in_dir = ls_files(&indexing_settings, &true_path, true).unwrap_or(vec![]);
                 construct_tree_out_of_flat_list_of_paths(&paths_in_dir)
             },
             None => construct_tree_out_of_flat_list_of_paths(&paths_from_anywhere)

--- a/src/tools/tool_tree.rs
+++ b/src/tools/tool_tree.rs
@@ -66,8 +66,7 @@ impl Tool for ToolTree {
                 }
 
                 let workspace_indexing_settings = load_indexing_settings_if_needed(gcx.clone()).await;
-                let indexing_settings = workspace_indexing_settings.get_indexing_settings(true_path.clone());
-                let paths_in_dir = ls_files(&indexing_settings, &true_path, true).unwrap_or(vec![]);
+                let paths_in_dir = ls_files(&workspace_indexing_settings, &true_path, true).unwrap_or(vec![]);
                 construct_tree_out_of_flat_list_of_paths(&paths_in_dir)
             },
             None => construct_tree_out_of_flat_list_of_paths(&paths_from_anywhere)


### PR DESCRIPTION
DONE/TEST:
 - read all .refact/indexing.yaml from all project_dirs
 - move all blacklisted_dirs logic to check corresponding .refact/indexing.yaml (default if not exists)
 - ls_files with additional_indexing_dirs check

TODO:
 - additional_indexing_dirs matching fix
 - .refact/indexing.yaml template for each project_dir
 - additional_indexing_dirs for _ls_files_under_version_control_recursive function