### PR TITLE
deepseek models

### DIFF
--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -590,6 +590,22 @@ pub const KNOWN_MODELS: &str = r####"
                 "PASSTHROUGH": {}
             }
         },
+        "deepseek-chat": {
+            "n_ctx": 64000,
+            "supports_tools": true,
+            "supports_multimodality": false,
+            "supports_scratchpads": {
+                "PASSTHROUGH": {}
+            }
+        },
+        "deepseek-reasoner": {
+            "n_ctx": 64000,
+            "supports_tools": false,
+            "supports_multimodality": false,
+            "supports_scratchpads": {
+                "PASSTHROUGH": {}
+            }
+        },
         "qwen2.5/coder/0.5b/instruct": {
             "n_ctx": 8192,
             "supports_tools": false,
@@ -656,7 +672,10 @@ pub const KNOWN_MODELS: &str = r####"
         "gemini-1.5-flash": "Xenova/gemma2-tokenizer",
         "gemini-1.5-flash-8b": "Xenova/gemma2-tokenizer",
         "gemini-1.5-pro": "Xenova/gemma2-tokenizer",
-        "gemini-2.0-exp-advanced": "Xenova/gemma2-tokenizer"
+        "gemini-2.0-exp-advanced": "Xenova/gemma2-tokenizer",
+
+        "deepseek-chat":     "deepseek-ai/DeepSeek-V3",
+        "deepseek-reasoner": "deepseek-ai/DeepSeek-R1"
     }
 }
 "####;

--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -238,6 +238,15 @@ pub const KNOWN_MODELS: &str = r####"
                 "grok-2-vision"
             ]
         },
+        "deepseek-chat": {
+            "n_ctx": 64000,
+            "supports_scratchpads": {
+                "REPLACE_PASSTHROUGH": {
+                    "context_format": "chat",
+                    "rag_ratio": 0.5
+                }
+            }
+        },
         "qwen2.5/coder/0.5b/instruct": {
             "n_ctx": 8192,
             "supports_scratchpads": {

--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -603,6 +603,7 @@ pub const KNOWN_MODELS: &str = r####"
             "n_ctx": 64000,
             "supports_tools": true,
             "supports_multimodality": false,
+            "supports_agent": true,
             "supports_scratchpads": {
                 "PASSTHROUGH": {}
             }


### PR DESCRIPTION
For better UX we should:
* add reasoning part limitation param (see docs)
* pass supports_multimodality into tools (cat and chrome for now) to prevent usage of visual

UPD
from deepseek docs: Note that the CoT output can reach up to 32K tokens, and the parameter to control the CoT length (reasoning_effort) will be available soon