### PR TITLE
fix: handle temperature parameter for o3-mini model

### DIFF
--- a/src/caps.rs
+++ b/src/caps.rs
@@ -38,6 +38,8 @@ pub struct ModelRecord {
     pub supports_clicks: bool,
     #[serde(default)]
     pub supports_agent: bool,
+    #[serde(default)]
+    pub supports_temperature: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -415,6 +417,9 @@ fn apply_models_dict_patch(caps: &mut CodeAssistantCaps) {
         }
         if rec_patched.supports_tools {
             rec.supports_tools = rec_patched.supports_tools;
+        }
+        if rec_patched.supports_temperature {
+            rec.supports_temperature = rec_patched.supports_temperature;
         }
     }
 

--- a/src/known_models.rs
+++ b/src/known_models.rs
@@ -358,6 +358,7 @@ pub const KNOWN_MODELS: &str = r####"
             "supports_tools": true,
             "supports_multimodality": false,
             "supports_agent": true,
+            "supports_temperature": false,
             "supports_scratchpads": {
                 "PASSTHROUGH": {
                 }

--- a/src/subchat.rs
+++ b/src/subchat.rs
@@ -50,11 +50,17 @@ async fn create_chat_post_and_scratchpad(
         );
     }
 
+    let temperature_to_use = {
+        let caps_lock = caps.read().unwrap();
+        let model_record = caps_lock.code_chat_models.get(model_name).ok_or_else(|| format!("Model {} not found in code_chat_models", model_name))?;
+        if model_record.supports_temperature { temperature } else { None }
+    };
+
     let mut chat_post = ChatPost {
         messages: messages.iter().map(|x|json!(x)).collect(),
         parameters: SamplingParameters {
             max_new_tokens,
-            temperature,
+            temperature: temperature_to_use,
             top_p: None,
             stop: vec![],
             n: Some(n),
@@ -63,7 +69,7 @@ async fn create_chat_post_and_scratchpad(
         model: model_name.to_string(),
         scratchpad: "".to_string(),
         stream: Some(false),
-        temperature,
+        temperature: temperature_to_use,
         max_tokens: 0,
         n: Some(n),
         tools,


### PR DESCRIPTION
- Add supports_temperature flag to ModelRecord
- Set supports_temperature: false for o3-mini model
- Add logic to check if temperature is supported before including it
- Fix borrow issues with RwLock

This fixes the error 'Unsupported parameter: temperature is not supported with this model' when using o3-mini model.