### PR TITLE
single-line completion fix

### DIFF
--- a/src/forward_to_openai_endpoint.rs
+++ b/src/forward_to_openai_endpoint.rs
@@ -21,6 +21,7 @@ pub async fn forward_to_openai_style_endpoint(
     endpoint_template: &String,
     endpoint_chat_passthrough: &String,
     sampling_parameters: &SamplingParameters,
+    is_metadata_supported: bool,
     meta: Option<ChatMeta>
 ) -> Result<serde_json::Value, String> {
     let is_passthrough = prompt.starts_with("PASSTHROUGH ");
@@ -31,7 +32,7 @@ pub async fn forward_to_openai_style_endpoint(
     if !bearer.is_empty() {
         headers.insert(AUTHORIZATION, HeaderValue::from_str(format!("Bearer {}", bearer).as_str()).unwrap());
     }
-    if meta.is_some() {
+    if is_metadata_supported {
         headers.insert(USER_AGENT, HeaderValue::from_str(format!("refact-lsp {}", crate::version::build_info::PKG_VERSION).as_str()).unwrap());
     }
     let mut data = json!({
@@ -103,6 +104,7 @@ pub async fn forward_to_openai_style_endpoint_streaming(
     endpoint_template: &String,
     endpoint_chat_passthrough: &String,
     sampling_parameters: &SamplingParameters,
+    is_metadata_supported: bool,
     meta: Option<ChatMeta>
 ) -> Result<EventSource, String> {
     let is_passthrough = prompt.starts_with("PASSTHROUGH ");
@@ -113,7 +115,7 @@ pub async fn forward_to_openai_style_endpoint_streaming(
     if !bearer.is_empty() {
         headers.insert(AUTHORIZATION, HeaderValue::from_str(format!("Bearer {}", bearer).as_str()).unwrap());
     }
-    if meta.is_some() {
+    if is_metadata_supported {
         headers.insert(USER_AGENT, HeaderValue::from_str(format!("refact-lsp {}", crate::version::build_info::PKG_VERSION).as_str()).unwrap());
     }
 

--- a/src/restream.rs
+++ b/src/restream.rs
@@ -102,6 +102,7 @@ pub async fn scratchpad_interaction_not_stream_json(
 
     let mut save_url: String = String::new();
     let _ = slowdown_arc.acquire().await;
+    let metadata_supported = crate::global_context::is_metadata_supported(gcx.clone()).await;
     let mut model_says = if only_deterministic_messages {
         save_url = "only-det-messages".to_string();
         Ok(serde_json::Value::Object(serde_json::Map::new()))
@@ -126,6 +127,7 @@ pub async fn scratchpad_interaction_not_stream_json(
             &endpoint_template,
             &endpoint_chat_passthrough,
             &parameters,  // includes n
+            metadata_supported,
             meta
         ).await
     }.map_err(|e| {
@@ -394,6 +396,7 @@ pub async fn scratchpad_interaction_stream(
                 break;
             }
             // info!("prompt: {:?}", prompt);
+            let metadata_supported = crate::global_context::is_metadata_supported(gcx.clone()).await;
             let event_source_maybe = if endpoint_style == "hf" {
                 crate::forward_to_hf_endpoint::forward_to_hf_style_endpoint_streaming(
                     &mut save_url,
@@ -415,6 +418,7 @@ pub async fn scratchpad_interaction_stream(
                     &endpoint_template,
                     &endpoint_chat_passthrough,
                     &my_parameters,
+                    metadata_supported,
                     meta
                 ).await
             };

--- a/src/scratchpad_abstract.rs
+++ b/src/scratchpad_abstract.rs
@@ -24,6 +24,7 @@ impl FinishReason {
         match s {
             "" => FinishReason::None,
             "stop" => FinishReason::Stop,
+            "stop-eot" => FinishReason::Stop,
             "tool_calls" => FinishReason::Stop,
             "length" => FinishReason::Length,
             "scratchpad-stop" => FinishReason::ScratchpadStop,

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -44,8 +44,8 @@ const MIN_ROWS_TO_SKIP_CARET: usize = 2;
 const SUBBLOCK_REQUIRED_TOKENS: usize = 128;
 const CURSORFILE_MIN_TOKENS: usize = 128;
 const MAX_NEW_TOKENS: usize = 1024;  // it's quite high since we want to avoid having a stripped message
-const TEMPERATURE_INITIAL: f32 = 0.2;
-const TEMPERATURE_NOCACHE: f32 = 0.6;
+const TEMPERATURE_INITIAL: f32 = 0.0;
+const TEMPERATURE_NOCACHE: f32 = 0.5;
 
 #[derive(Debug, Clone)]
 pub struct SubBlock {
@@ -674,9 +674,6 @@ impl ScratchpadAbstract for CodeCompletionReplaceScratchpad {
         sampling_parameters_to_patch.max_new_tokens = MAX_NEW_TOKENS;
         sampling_parameters_to_patch.temperature = if !self.post.no_cache { Some(TEMPERATURE_INITIAL) } else { Some(TEMPERATURE_NOCACHE) };
         sampling_parameters_to_patch.stop = vec![self.t.eot.clone()];
-        if !self.post.inputs.multiline {
-            sampling_parameters_to_patch.stop.push("\n".to_string());
-        }
         let cpath = crate::files_correction::canonical_path(&self.post.inputs.cursor.file);
         let source = self
             .post

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -73,7 +73,7 @@ impl SubBlock {
                 .join("")
                 .as_str(),
         );
-        Ok(format!("<BLOCK_OF_CDDE>:\n```\n{code}\n```"))
+        Ok(format!("<BLOCK_OF_CODE>:\n```\n{code}\n```"))
     }
 
     fn before_lines_str(&self) -> String {
@@ -900,9 +900,10 @@ impl ScratchpadAbstract for CodeCompletionReplacePassthroughScratchpad {
         sampling_parameters_to_patch.max_new_tokens = MAX_NEW_TOKENS;
         sampling_parameters_to_patch.temperature = if !self.post.no_cache { Some(TEMPERATURE_INITIAL) } else { Some(TEMPERATURE_NOCACHE) };
         sampling_parameters_to_patch.stop = vec![];
-        if !self.post.inputs.multiline {
-            sampling_parameters_to_patch.stop.push("\n".to_string());
-        }
+        // if !self.post.inputs.multiline {
+        //     info!("multiline = {}", self.post.inputs.multiline);
+            // sampling_parameters_to_patch.stop.push("\n".to_string());
+        // }
         let cpath = crate::files_correction::canonical_path(&self.post.inputs.cursor.file);
         let source = self
             .post

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -64,7 +64,7 @@ impl SubBlock {
             .collect::<Vec<_>>()
             .join("");
 
-        code.push_str(format!("{}<CURSOR>\n", self.cursor_line).as_str());
+        code.push_str(format!("{}<CURSOR>\n", self.cursor_line.trim_end().to_string()).as_str());
         code.push_str(
             self.after_lines
                 .iter()
@@ -899,7 +899,7 @@ impl ScratchpadAbstract for CodeCompletionReplacePassthroughScratchpad {
         let use_rag = self.t.rag_ratio > 0.0 && self.post.use_ast && self.ast_service.is_some();
         sampling_parameters_to_patch.max_new_tokens = MAX_NEW_TOKENS;
         sampling_parameters_to_patch.temperature = if !self.post.no_cache { Some(TEMPERATURE_INITIAL) } else { Some(TEMPERATURE_NOCACHE) };
-        sampling_parameters_to_patch.stop = vec![self.t.eot.clone()];
+        sampling_parameters_to_patch.stop = vec![];
         if !self.post.inputs.multiline {
             sampling_parameters_to_patch.stop.push("\n".to_string());
         }

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -899,11 +899,7 @@ impl ScratchpadAbstract for CodeCompletionReplacePassthroughScratchpad {
         let use_rag = self.t.rag_ratio > 0.0 && self.post.use_ast && self.ast_service.is_some();
         sampling_parameters_to_patch.max_new_tokens = MAX_NEW_TOKENS;
         sampling_parameters_to_patch.temperature = if !self.post.no_cache { Some(TEMPERATURE_INITIAL) } else { Some(TEMPERATURE_NOCACHE) };
-        sampling_parameters_to_patch.stop = vec![];
-        // if !self.post.inputs.multiline {
-        //     info!("multiline = {}", self.post.inputs.multiline);
-            // sampling_parameters_to_patch.stop.push("\n".to_string());
-        // }
+        sampling_parameters_to_patch.stop = vec![]; // avoid model cutting completion too early 
         let cpath = crate::files_correction::canonical_path(&self.post.inputs.cursor.file);
         let source = self
             .post

--- a/src/scratchpads/code_completion_replace.rs
+++ b/src/scratchpads/code_completion_replace.rs
@@ -405,6 +405,7 @@ fn process_n_choices(
                 info!("unprocessed {i} response_n_choice\n{}", x);
             }
             if finish_reasons[i] == FinishReason::Stop && !x.contains("```") {
+                warn!("completion refused: no code block found in the model response");
                 return json!({
                     "index": i,
                     "code_completion": "",


### PR DESCRIPTION
Reduce temperature values (initial: 0.2 -> 0.0, no-cache: 0.6 -> 0.5)… and remove newline stop token for multiline inputs to improve completion consistency.