### PR TITLE
Create refact.yaml

### DIFF
--- a/bring_your_own_key/refact.yaml
+++ b/bring_your_own_key/refact.yaml
@@ -1,0 +1,12 @@
+
+cloud_name: Refact API
+
+# Under development
+#chat_endpoint: "http://localhost:8008/v1/chat/completions"
+#chat_model: "qwen2.5/coder/1.5b/instruct"
+
+embedding_endpoint: "http://localhost:8008/v1/embeddings"
+embedding_model: "thenlper/gte-base"
+
+completion_endpoint: "http://localhost:8008/v1/completions"
+completion_model: "Refact/1.6B"


### PR DESCRIPTION
Endpoints for refact selfhost. If someone need to seperate chat and completion with different refact endpoints.
docker run -d --rm -p 8008:8008 -v perm-storage:/perm_storage --gpus all smallcloud/refact_self_hosting