### PR TITLE
change approach for rollback to preview -> apply instead of apply -> …

### DIFF
--- a/src/git/checkpoints.rs
+++ b/src/git/checkpoints.rs
@@ -27,29 +27,50 @@ impl Checkpoint {
     }
 }
 
-fn open_shadow_repos(paths: &[PathBuf], allow_init: bool, nested: bool, cache_dir: &Path) -> Result<Vec<Repository>, String> {
-    let mut result = Vec::new();
-    for path in paths {
-        let path_hash = official_text_hashing_function(&path.to_string_lossy().to_string());
-        let git_dir_path = if nested {
-            cache_dir.join("shadow_git").join("nested").join(&path_hash)
-        } else {
-            cache_dir.join("shadow_git").join(&path_hash)
-        };
-        let nested_repo = if allow_init {
-            open_or_init_repo(&git_dir_path).map_err_to_string()
-        } else {
-            Repository::open(&git_dir_path).map_err_to_string()
-        }?;
-        nested_repo.set_workdir(path, false).map_err_to_string()?;
-        for blacklisted_dir in  BLACKLISTED_DIRS {
-            if let Err(e) = nested_repo.add_ignore_rule(blacklisted_dir) {
-                tracing::warn!("Failed to add ignore rule for {blacklisted_dir}: {e}");
+async fn open_shadow_repo_and_nested_repos(
+    gcx: Arc<ARwLock<GlobalContext>>, workspace_folder: &Path, allow_init_main_repo: bool,
+) -> Result<(Repository, Vec<Repository>, String), String> {
+    fn open_repos(paths: &[PathBuf], allow_init: bool, nested: bool, cache_dir: &Path) -> Result<Vec<Repository>, String> {
+        let mut result = Vec::new();
+        for path in paths {
+            let path_hash = official_text_hashing_function(&path.to_string_lossy().to_string());
+            let git_dir_path = if nested {
+                cache_dir.join("shadow_git").join("nested").join(&path_hash)
+            } else {
+                cache_dir.join("shadow_git").join(&path_hash)
+            };
+            let nested_repo = if allow_init {
+                open_or_init_repo(&git_dir_path).map_err_to_string()
+            } else {
+                Repository::open(&git_dir_path).map_err_to_string()
+            }?;
+            nested_repo.set_workdir(path, false).map_err_to_string()?;
+            for blacklisted_dir in  BLACKLISTED_DIRS {
+                if let Err(e) = nested_repo.add_ignore_rule(blacklisted_dir) {
+                    tracing::warn!("Failed to add ignore rule for {blacklisted_dir}: {e}");
+                }
             }
+            result.push(nested_repo);
         }
-        result.push(nested_repo);
+        Ok(result)
     }
-    Ok(result)
+    
+    let (cache_dir, vcs_roots) = {
+        let gcx_locked = gcx.read().await;
+        (gcx_locked.cache_dir.clone(), gcx_locked.documents_state.workspace_vcs_roots.clone())
+    };
+    let nested_vcs_roots: Vec<PathBuf> = {
+        let vcs_roots_locked = vcs_roots.lock().unwrap();
+        vcs_roots_locked.iter()
+            .filter(|vcs| vcs.starts_with(&workspace_folder) && **vcs != workspace_folder).cloned().collect()
+    };
+    let workspace_folder_hash = official_text_hashing_function(&workspace_folder.to_string_lossy().to_string());
+
+    let repo = open_repos(&[workspace_folder.to_path_buf()], allow_init_main_repo, false, &cache_dir)?
+        .into_iter().next().unwrap();
+    let nested_repos = open_repos(&nested_vcs_roots, true, true, &cache_dir)?;
+
+    Ok((repo, nested_repos, workspace_folder_hash))
 }
 
 fn get_file_changes_from_nested_repos<'a>(
@@ -82,32 +103,20 @@ pub async fn create_workspace_checkpoint(
     gcx: Arc<ARwLock<GlobalContext>>,
     prev_checkpoint: Option<&Checkpoint>,
     chat_id: &str,
-) -> Result<(Checkpoint, Repository, Vec<Repository>), String> {
-    let (cache_dir, vcs_roots) = {
-        let gcx_locked = gcx.read().await;
-        (gcx_locked.cache_dir.clone(), gcx_locked.documents_state.workspace_vcs_roots.clone())
-    };
+) -> Result<(Checkpoint, Repository), String> {
+    let t0 = Instant::now();
+
     let workspace_folder = get_active_workspace_folder(gcx.clone()).await
         .ok_or_else(|| "No active workspace folder".to_string())?;
-    let nested_vcs_roots: Vec<PathBuf> = {
-        let vcs_roots_locked = vcs_roots.lock().unwrap();
-        vcs_roots_locked.iter()
-            .filter(|vcs| vcs.starts_with(&workspace_folder) && **vcs != workspace_folder).cloned().collect()
-    };
-    let workspace_folder_hash = official_text_hashing_function(&workspace_folder.to_string_lossy().to_string());
-
+    let (repo, nested_repos, workspace_folder_hash) = 
+        open_shadow_repo_and_nested_repos(gcx.clone(), &workspace_folder, false).await?;
+    
     if let Some(prev_checkpoint) = prev_checkpoint {
         if prev_checkpoint.workspace_hash() != workspace_folder_hash {
             return Err("Can not create checkpoint for different workspace folder".to_string());
         }
     }
 
-    let t0 = Instant::now();
-
-    let repo = open_shadow_repos(&[workspace_folder.clone()], false, false, &cache_dir)?
-        .into_iter().next().unwrap();
-    let nested_repos = open_shadow_repos(&nested_vcs_roots, true, true, &cache_dir)?;
-    
     let has_commits = repo.head().map(|head| head.target().is_some()).unwrap_or(false);
     if !has_commits {
         return Err("No commits in shadow git repo.".to_string());
@@ -134,15 +143,13 @@ pub async fn create_workspace_checkpoint(
 
     tracing::info!("Checkpoint created in {:.2}s", t0.elapsed().as_secs_f64());
 
-    Ok((checkpoint, repo, nested_repos))
+    Ok((checkpoint, repo))
 }
 
-pub async fn restore_workspace_checkpoint(
+pub async fn preview_changes_for_workspace_checkpoint(
     gcx: Arc<ARwLock<GlobalContext>>, checkpoint_to_restore: &Checkpoint, chat_id: &str
-) -> Result<(Checkpoint, Vec<FileChange>, DateTime<Utc>), String> {
-    
-    let (checkpoint_for_undo, repo, nested_repos) = 
-        create_workspace_checkpoint(gcx.clone(), Some(checkpoint_to_restore), chat_id).await?;
+) -> Result<(Vec<FileChange>, DateTime<Utc>, Checkpoint), String> {
+    let (checkpoint_for_undo, repo) = create_workspace_checkpoint(gcx.clone(), Some(checkpoint_to_restore), chat_id).await?;
 
     let commit_to_restore_oid = Oid::from_str(&checkpoint_to_restore.commit_hash).map_err_to_string()?;
     let reverted_to = get_commit_datetime(&repo, &commit_to_restore_oid)?;
@@ -158,8 +165,24 @@ pub async fn restore_workspace_checkpoint(
         };
     }
 
-    checkout_head_and_branch_to_commit(&repo, &format!("refact-{chat_id}"), &commit_to_restore_oid)?;
+    Ok((files_changed, reverted_to, checkpoint_for_undo))
+}
 
+pub async fn restore_workspace_checkpoint(
+    gcx: Arc<ARwLock<GlobalContext>>, checkpoint_to_restore: &Checkpoint, chat_id: &str
+) -> Result<(), String> {
+    let workspace_folder = get_active_workspace_folder(gcx.clone()).await
+        .ok_or_else(|| "No active workspace folder".to_string())?;
+    let (repo, nested_repos, workspace_folder_hash) = 
+        open_shadow_repo_and_nested_repos(gcx.clone(), &workspace_folder, false).await?;
+    if checkpoint_to_restore.workspace_hash() != workspace_folder_hash {
+        return Err("Can not restore checkpoint for different workspace folder".to_string());
+    }
+
+    let commit_to_restore_oid = Oid::from_str(&checkpoint_to_restore.commit_hash).map_err_to_string()?;
+
+    checkout_head_and_branch_to_commit(&repo, &format!("refact-{chat_id}"), &commit_to_restore_oid)?;
+    
     for nested_repo in &nested_repos {
         let reset_index_result = nested_repo.index()
             .and_then(|mut index| {
@@ -178,33 +201,19 @@ pub async fn restore_workspace_checkpoint(
         }
     }
 
-    Ok((checkpoint_for_undo, files_changed, reverted_to))
+    Ok(())
 }
 
 pub async fn init_shadow_repos_if_needed(gcx: Arc<ARwLock<GlobalContext>>) -> () {
     let workspace_folders = get_project_dirs(gcx.clone()).await;
-    let (cache_dir, workspace_vcs_roots_arc) = {
-        let gcx_locked = gcx.read().await;
-        (gcx_locked.cache_dir.clone(), gcx_locked.documents_state.workspace_vcs_roots.clone())
-    };
-    let workspace_vcs_roots = workspace_vcs_roots_arc.lock().unwrap().clone();
 
     for workspace_folder in workspace_folders {
         let workspace_folder_str = workspace_folder.to_string_lossy().to_string();
-        let nested_vcs_roots: Vec<PathBuf> = workspace_vcs_roots.iter()
-            .filter(|r| r.starts_with(&workspace_folder) && **r != workspace_folder).cloned().collect();
 
-        let repo = match open_shadow_repos(&[workspace_folder], true, false, &cache_dir) {
-            Ok(repos) => repos.into_iter().next().unwrap(),
+        let (repo, nested_repos) = match open_shadow_repo_and_nested_repos(gcx.clone(), &workspace_folder, true).await {
+            Ok((repo, nested_repos, _)) => (repo, nested_repos),
             Err(e) => {
                 tracing::error!("Failed to open or init shadow repo for {workspace_folder_str}: {e}");
-                continue;
-            }
-        };
-        let nested_repos = match open_shadow_repos(&nested_vcs_roots, true, true, &cache_dir) {
-            Ok(nested_repos) => nested_repos,
-            Err(e) => {
-                tracing::error!("Failed to open or init nested repos for {workspace_folder_str}: {e}");
                 continue;
             }
         };

--- a/src/http/routers/v1.rs
+++ b/src/http/routers/v1.rs
@@ -23,7 +23,7 @@ use crate::http::routers::v1::chat::{handle_v1_chat, handle_v1_chat_completions}
 use crate::http::routers::v1::chat_based_handlers::handle_v1_commit_message_from_diff;
 use crate::http::routers::v1::dashboard::get_dashboard_plots;
 use crate::http::routers::v1::docker::{handle_v1_docker_container_action, handle_v1_docker_container_list};
-use crate::http::routers::v1::git::{handle_v1_git_commit, handle_v1_restore_checkpoints};
+use crate::http::routers::v1::git::{handle_v1_git_commit, handle_v1_checkpoints_preview, handle_v1_checkpoints_restore};
 use crate::http::routers::v1::graceful_shutdown::handle_v1_graceful_shutdown;
 use crate::http::routers::v1::snippet_accepted::handle_v1_snippet_accepted;
 use crate::http::routers::v1::telemetry_network::handle_v1_telemetry_network;
@@ -140,7 +140,8 @@ pub fn make_v1_router() -> Router {
         .route("/patch-single-file-from-ticket", telemetry_post!(handle_v1_patch_single_file_from_ticket))
         .route("/patch-apply-all", telemetry_post!(handle_v1_patch_apply_all))
 
-        .route("/restore-checkpoints", telemetry_post!(handle_v1_restore_checkpoints))
+        .route("/checkpoints-preview", telemetry_post!(handle_v1_checkpoints_preview))
+        .route("/checkpoints-restore", telemetry_post!(handle_v1_checkpoints_restore))
 
         .route("/links", telemetry_post!(handle_v1_links))
 

--- a/src/http/routers/v1/chat.rs
+++ b/src/http/routers/v1/chat.rs
@@ -230,7 +230,7 @@ async fn _chat(
             if [ChatMode::AGENT, ChatMode::CONFIGURE, ChatMode::PROJECT_SUMMARY].contains(&chat_post.meta.chat_mode) 
                 && latest_user_msg.checkpoints.is_empty() {
                 match create_workspace_checkpoint(gcx.clone(), latest_checkpoint.as_ref(), &chat_post.meta.chat_id).await {
-                    Ok((checkpoint, _, _)) => {
+                    Ok((checkpoint, _)) => {
                         tracing::info!("Checkpoint created: {:?}", checkpoint);
                         latest_user_msg.checkpoints = vec![checkpoint];
                     },


### PR DESCRIPTION
…undo

Now there are two separate endpoints: /checkpoints-preview and /checkpoints-restore

Unified way to open repos and nested repos