### PR TITLE
sqlitevec no index

### DIFF
--- a/src/vecdb/vdb_sqlite.rs
+++ b/src/vecdb/vdb_sqlite.rs
@@ -104,7 +104,7 @@ async fn migrate_202501(conn: &Connection, embedding_size: i32, emb_table_name: 
         conn.execute(&format!(
             "CREATE VIRTUAL TABLE IF NOT EXISTS {emb_table_name} using vec0(
               embedding float[{embedding_size}] distance_metric=cosine,
-              scope TEXT PARTITION KEY,
+              scope TEXT,
               +start_line INTEGER,
               +end_line INTEGER
             );"), [])?;


### PR DESCRIPTION
Remove the PARTITION KEY attribute from the "scope" column in SQLite virtual table creation.